### PR TITLE
Integrate sanctuary-type-identifiers

### DIFF
--- a/fluture.js
+++ b/fluture.js
@@ -11,12 +11,20 @@
 
   /*istanbul ignore next*/
   if(module && typeof module.exports !== 'undefined'){
-    module.exports = f(require('inspect-f'), require('sanctuary-type-classes'));
+    module.exports = f(
+      require('inspect-f'),
+      require('sanctuary-type-classes'),
+      require('sanctuary-type-identifiers')
+    );
   }else{
-    global.Fluture = f(global.inspectf, global.sanctuaryTypeClasses);
+    global.Fluture = f(
+      global.inspectf,
+      global.sanctuaryTypeClasses,
+      global.sanctuaryTypeIdentifiers
+    );
   }
 
-}(/*istanbul ignore next*/(global || window || this), function(inspectf, Z){
+}(/*istanbul ignore next*/(global || window || this), function(inspectf, Z, type){
 
   'use strict';
 
@@ -45,7 +53,7 @@
   }
 
   function isFuture(m){
-    return m instanceof Future || Boolean(m) && m['@@type'] === TYPEOF_FUTURE;
+    return m instanceof Future || type(m) === TYPEOF_FUTURE;
   }
 
   function isThenable(m){
@@ -148,7 +156,7 @@
     return new ChainRec(f, init);
   }
 
-  Future.prototype['@@type'] = TYPEOF_FUTURE;
+  Future['@@type'] = TYPEOF_FUTURE;
   Future.prototype._f = null;
   Future.prototype.extractLeft = function Future$extractLeft(){ return [] };
   Future.prototype.extractRight = function Future$extractRight(){ return [] };

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
   ],
   "dependencies": {
     "inspect-f": "^1.2.0",
-    "sanctuary-type-classes": "^3.0.0"
+    "sanctuary-type-classes": "^3.0.0",
+    "sanctuary-type-identifiers": "^1.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.18.0",
@@ -76,7 +77,6 @@
     "remark-cli": "^2.1.0",
     "remark-validate-links": "^5.0.0",
     "rimraf": "^2.4.3",
-    "sanctuary": "^0.11.1",
     "xyz": "^2.0.1"
   }
 }

--- a/test/1.future.test.js
+++ b/test/1.future.test.js
@@ -4,13 +4,12 @@ const expect = require('chai').expect;
 const Future = require('../fluture.js');
 const U = require('./util');
 const F = require('./futures');
-const S = require('sanctuary');
+const type = require('sanctuary-type-identifiers');
 
 describe('Future', () => {
 
-  it('instances are considered members of Future through @@type', () => {
-    expect(S.type(F.mock)).to.equal('fluture/Future');
-    expect(S.is(Future, F.mock)).to.equal(true);
+  it('instances are considered members of fluture/Future by sanctuary-type-identifiers', () => {
+    expect(type(F.mock)).to.equal('fluture/Future');
   });
 
   describe('.util', () => {

--- a/test/2.safe-future.test.js
+++ b/test/2.safe-future.test.js
@@ -4,6 +4,7 @@ const expect = require('chai').expect;
 const Future = require('../fluture.js');
 const SafeFuture = Future.classes.SafeFuture;
 const U = require('./util');
+const type = require('sanctuary-type-identifiers');
 
 describe('Future()', () => {
 
@@ -34,6 +35,10 @@ describe('SafeFuture', () => {
 
   it('extends Future', () => {
     expect(new SafeFuture).to.be.an.instanceof(Future);
+  });
+
+  it('is considered a member of fluture/Fluture', () => {
+    expect(type(new SafeFuture)).to.equal('fluture/Future');
   });
 
   describe('#fork()', () => {

--- a/test/3.future-after.test.js
+++ b/test/3.future-after.test.js
@@ -4,6 +4,7 @@ const expect = require('chai').expect;
 const Future = require('../fluture.js');
 const FutureAfter = Future.classes.FutureAfter;
 const U = require('./util');
+const type = require('sanctuary-type-identifiers');
 
 describe('Future.after()', () => {
 
@@ -31,6 +32,10 @@ describe('FutureAfter', () => {
 
   it('extends Future', () => {
     expect(m).to.be.an.instanceof(Future);
+  });
+
+  it('is considered a member of fluture/Fluture', () => {
+    expect(type(m)).to.equal('fluture/Future');
   });
 
   describe('#fork()', () => {

--- a/test/3.future-of.test.js
+++ b/test/3.future-of.test.js
@@ -5,6 +5,7 @@ const FL = require('fantasy-land');
 const Future = require('../fluture.js');
 const FutureOf = Future.classes.FutureOf;
 const U = require('./util');
+const type = require('sanctuary-type-identifiers');
 
 describe('Future.of()', () => {
 
@@ -24,6 +25,10 @@ describe('FutureOf', () => {
 
   it('extends Future', () => {
     expect(m).to.be.an.instanceof(Future);
+  });
+
+  it('is considered a member of fluture/Fluture', () => {
+    expect(type(m)).to.equal('fluture/Future');
   });
 
   describe('#fork()', () => {

--- a/test/3.future-reject-after.test.js
+++ b/test/3.future-reject-after.test.js
@@ -4,6 +4,7 @@ const expect = require('chai').expect;
 const Future = require('../fluture.js');
 const FutureRejectAfter = Future.classes.FutureRejectAfter;
 const U = require('./util');
+const type = require('sanctuary-type-identifiers');
 
 describe('Future.rejectAfter()', () => {
 
@@ -31,6 +32,10 @@ describe('FutureRejectAfter', () => {
 
   it('extends Future', () => {
     expect(m).to.be.an.instanceof(Future);
+  });
+
+  it('is considered a member of fluture/Fluture', () => {
+    expect(type(m)).to.equal('fluture/Future');
   });
 
   describe('#fork()', () => {

--- a/test/3.future-reject.test.js
+++ b/test/3.future-reject.test.js
@@ -4,6 +4,7 @@ const expect = require('chai').expect;
 const Future = require('../fluture.js');
 const FutureReject = Future.classes.FutureReject;
 const U = require('./util');
+const type = require('sanctuary-type-identifiers');
 
 describe('Future.reject()', () => {
 
@@ -19,6 +20,10 @@ describe('FutureReject', () => {
 
   it('extends Future', () => {
     expect(m).to.be.an.instanceof(Future);
+  });
+
+  it('is considered a member of fluture/Fluture', () => {
+    expect(type(m)).to.equal('fluture/Future');
   });
 
   describe('#fork()', () => {

--- a/test/4.chain-rec.test.js
+++ b/test/4.chain-rec.test.js
@@ -4,6 +4,7 @@ const expect = require('chai').expect;
 const Future = require('../fluture.js');
 const ChainRec = Future.classes.ChainRec;
 const U = require('./util');
+const type = require('sanctuary-type-identifiers');
 
 describe('Future.class()', () => {
 
@@ -29,6 +30,10 @@ describe('ChainRec', () => {
 
   it('extends Future', () => {
     expect(new ChainRec).to.be.an.instanceof(Future);
+  });
+
+  it('is considered a member of fluture/Fluture', () => {
+    expect(type(new ChainRec)).to.equal('fluture/Future');
   });
 
   describe('#fork()', () => {

--- a/test/5.future-and.test.js
+++ b/test/5.future-and.test.js
@@ -4,8 +4,13 @@ const expect = require('chai').expect;
 const Future = require('../fluture.js');
 const U = require('./util');
 const F = require('./futures');
+const type = require('sanctuary-type-identifiers');
 
 const testInstance = and => {
+
+  it('is considered a member of fluture/Fluture', () => {
+    expect(type(and(F.resolved, F.resolvedSlow))).to.equal('fluture/Future');
+  });
 
   describe('#fork()', () => {
 

--- a/test/5.future-ap.test.js
+++ b/test/5.future-ap.test.js
@@ -4,8 +4,13 @@ const expect = require('chai').expect;
 const Future = require('../fluture.js');
 const U = require('./util');
 const F = require('./futures');
+const type = require('sanctuary-type-identifiers');
 
 const testInstance = ap => {
+
+  it('is considered a member of fluture/Fluture', () => {
+    expect(type(ap(Future.of(1), Future.of(U.add(1))))).to.equal('fluture/Future');
+  });
 
   describe('#fork()', () => {
 

--- a/test/5.future-bimap.test.js
+++ b/test/5.future-bimap.test.js
@@ -3,8 +3,13 @@
 const expect = require('chai').expect;
 const Future = require('../fluture.js');
 const U = require('./util');
+const type = require('sanctuary-type-identifiers');
 
 const testInstance = bimap => {
+
+  it('is considered a member of fluture/Fluture', () => {
+    expect(type(bimap(Future.reject(1), U.add(1), U.failRes))).to.equal('fluture/Future');
+  });
 
   describe('#fork()', () => {
 

--- a/test/5.future-both.test.js
+++ b/test/5.future-both.test.js
@@ -4,8 +4,13 @@ const expect = require('chai').expect;
 const Future = require('../fluture.js');
 const U = require('./util');
 const F = require('./futures');
+const type = require('sanctuary-type-identifiers');
 
 const testInstance = both => {
+
+  it('is considered a member of fluture/Fluture', () => {
+    expect(type(both(F.resolved, F.resolvedSlow))).to.equal('fluture/Future');
+  });
 
   describe('#fork()', () => {
 

--- a/test/5.future-cache.test.js
+++ b/test/5.future-cache.test.js
@@ -4,8 +4,13 @@ const expect = require('chai').expect;
 const Future = require('../fluture.js');
 const CachedFuture = Future.classes.CachedFuture;
 const U = require('./util');
+const type = require('sanctuary-type-identifiers');
 
 const testInstance = cache => {
+
+  it('is considered a member of fluture/Fluture', () => {
+    expect(type(cache(Future.of(1)))).to.equal('fluture/Future');
+  });
 
   describe('#fork()', () => {
 

--- a/test/5.future-chain-rej.test.js
+++ b/test/5.future-chain-rej.test.js
@@ -4,8 +4,13 @@ const expect = require('chai').expect;
 const Future = require('../fluture.js');
 const U = require('./util');
 const F = require('./futures');
+const type = require('sanctuary-type-identifiers');
 
 const testInstance = chainRej => {
+
+  it('is considered a member of fluture/Fluture', () => {
+    expect(type(chainRej(F.rejected, () => F.resolved))).to.equal('fluture/Future');
+  });
 
   describe('#fork()', () => {
 

--- a/test/5.future-chain.test.js
+++ b/test/5.future-chain.test.js
@@ -4,8 +4,13 @@ const expect = require('chai').expect;
 const Future = require('../fluture.js');
 const U = require('./util');
 const F = require('./futures');
+const type = require('sanctuary-type-identifiers');
 
 const testInstance = chain => {
+
+  it('is considered a member of fluture/Fluture', () => {
+    expect(type(chain(F.resolved, () => F.resolvedSlow))).to.equal('fluture/Future');
+  });
 
   describe('#fork()', () => {
 

--- a/test/5.future-encase.test.js
+++ b/test/5.future-encase.test.js
@@ -4,6 +4,7 @@ const expect = require('chai').expect;
 const Future = require('../fluture.js');
 const FutureEncase = Future.classes.FutureEncase;
 const U = require('./util');
+const type = require('sanctuary-type-identifiers');
 
 const unaryNoop = a => void a;
 const binaryNoop = (a, b) => void b;
@@ -81,6 +82,10 @@ describe('FutureEncase', () => {
 
   it('extends Future', () => {
     expect(new FutureEncase).to.be.an.instanceof(Future);
+  });
+
+  it('is considered a member of fluture/Fluture', () => {
+    expect(type(new FutureEncase)).to.equal('fluture/Future');
   });
 
   describe('#fork()', () => {

--- a/test/5.future-finally.test.js
+++ b/test/5.future-finally.test.js
@@ -4,8 +4,13 @@ const expect = require('chai').expect;
 const Future = require('../fluture.js');
 const U = require('./util');
 const F = require('./futures');
+const type = require('sanctuary-type-identifiers');
 
 const testInstance = fin => {
+
+  it('is considered a member of fluture/Fluture', () => {
+    expect(type(fin(Future.of(1), Future.of(2)))).to.equal('fluture/Future');
+  });
 
   describe('#fork()', () => {
 

--- a/test/5.future-fold.test.js
+++ b/test/5.future-fold.test.js
@@ -3,8 +3,13 @@
 const expect = require('chai').expect;
 const Future = require('../fluture.js');
 const U = require('./util');
+const type = require('sanctuary-type-identifiers');
 
 const testInstance = fold => {
+
+  it('is considered a member of fluture/Fluture', () => {
+    expect(type(fold(Future.reject(1), U.add(1), U.sub(1)))).to.equal('fluture/Future');
+  });
 
   describe('#fork()', () => {
 

--- a/test/5.future-from-promise.test.js
+++ b/test/5.future-from-promise.test.js
@@ -4,6 +4,7 @@ const expect = require('chai').expect;
 const Future = require('../fluture.js');
 const FutureFromPromise = Future.classes.FutureFromPromise;
 const U = require('./util');
+const type = require('sanctuary-type-identifiers');
 
 const unaryNoop = a => Promise.resolve(a);
 const binaryNoop = (a, b) => Promise.resolve(b);
@@ -82,6 +83,10 @@ describe('FutureFromPromise', () => {
 
   it('extends Future', () => {
     expect(new FutureFromPromise).to.be.an.instanceof(Future);
+  });
+
+  it('is considered a member of fluture/Fluture', () => {
+    expect(type(new FutureFromPromise)).to.equal('fluture/Future');
   });
 
   describe('#fork()', () => {

--- a/test/5.future-hook.test.js
+++ b/test/5.future-hook.test.js
@@ -4,8 +4,14 @@ const expect = require('chai').expect;
 const Future = require('../fluture.js');
 const U = require('./util');
 const F = require('./futures');
+const type = require('sanctuary-type-identifiers');
 
 const testInstance = hook => {
+
+  it('is considered a member of fluture/Fluture', () => {
+    const m = hook(Future.of(1), () => Future.of(2), () => Future.of(3));
+    expect(type(m)).to.equal('fluture/Future');
+  });
 
   describe('#fork()', () => {
 

--- a/test/5.future-map-rej.test.js
+++ b/test/5.future-map-rej.test.js
@@ -4,8 +4,13 @@ const expect = require('chai').expect;
 const Future = require('../fluture.js');
 const U = require('./util');
 const F = require('./futures');
+const type = require('sanctuary-type-identifiers');
 
 const testInstance = mapRej => {
+
+  it('is considered a member of fluture/Fluture', () => {
+    expect(type(mapRej(F.rejected, U.bang))).to.equal('fluture/Future');
+  });
 
   describe('#fork()', () => {
 

--- a/test/5.future-map.test.js
+++ b/test/5.future-map.test.js
@@ -4,8 +4,13 @@ const expect = require('chai').expect;
 const Future = require('../fluture.js');
 const U = require('./util');
 const F = require('./futures');
+const type = require('sanctuary-type-identifiers');
 
 const testInstance = map => {
+
+  it('is considered a member of fluture/Fluture', () => {
+    expect(type(map(Future.of(1), U.add(1)))).to.equal('fluture/Future');
+  });
 
   describe('#fork()', () => {
 

--- a/test/5.future-node.test.js
+++ b/test/5.future-node.test.js
@@ -4,6 +4,7 @@ const expect = require('chai').expect;
 const Future = require('../fluture.js');
 const FutureNode = Future.classes.FutureNode;
 const U = require('./util');
+const type = require('sanctuary-type-identifiers');
 
 describe('Future.node()', () => {
 
@@ -23,6 +24,10 @@ describe('FutureNode', () => {
 
   it('extends Future', () => {
     expect(new FutureNode).to.be.an.instanceof(Future);
+  });
+
+  it('is considered a member of fluture/Fluture', () => {
+    expect(type(new FutureNode)).to.equal('fluture/Future');
   });
 
   describe('#fork()', () => {

--- a/test/5.future-or.test.js
+++ b/test/5.future-or.test.js
@@ -4,8 +4,13 @@ const expect = require('chai').expect;
 const Future = require('../fluture.js');
 const U = require('./util');
 const F = require('./futures');
+const type = require('sanctuary-type-identifiers');
 
 const testInstance = or => {
+
+  it('is considered a member of fluture/Fluture', () => {
+    expect(type(or(F.resolved, F.resolvedSlow))).to.equal('fluture/Future');
+  });
 
   describe('#fork()', () => {
 

--- a/test/5.future-parallel.test.js
+++ b/test/5.future-parallel.test.js
@@ -5,6 +5,7 @@ const Future = require('../fluture.js');
 const FutureParallel = Future.classes.FutureParallel;
 const U = require('./util');
 const F = require('./futures');
+const type = require('sanctuary-type-identifiers');
 
 describe('Future.parallel()', () => {
 
@@ -36,6 +37,10 @@ describe('FutureParallel', () => {
 
   it('extends Future', () => {
     expect(new FutureParallel(1, [])).to.be.an.instanceof(Future);
+  });
+
+  it('is considered a member of fluture/Fluture', () => {
+    expect(type(new FutureParallel(1, []))).to.equal('fluture/Future');
   });
 
   describe('#fork()', () => {

--- a/test/5.future-race.test.js
+++ b/test/5.future-race.test.js
@@ -3,8 +3,15 @@
 const expect = require('chai').expect;
 const Future = require('../fluture.js');
 const U = require('./util');
+const type = require('sanctuary-type-identifiers');
 
 const testInstance = race => {
+
+  it('is considered a member of fluture/Fluture', () => {
+    const m1 = Future((rej, res) => void setTimeout(res, 15, 1));
+    const m2 = Future(rej => void setTimeout(rej, 5, U.error));
+    expect(type(race(m1, m2))).to.equal('fluture/Future');
+  });
 
   describe('#fork()', () => {
 

--- a/test/5.future-swap.test.js
+++ b/test/5.future-swap.test.js
@@ -3,8 +3,13 @@
 const expect = require('chai').expect;
 const Future = require('../fluture.js');
 const U = require('./util');
+const type = require('sanctuary-type-identifiers');
 
 const testInstance = swap => {
+
+  it('is considered a member of fluture/Fluture', () => {
+    expect(type(swap(Future.of(1)))).to.equal('fluture/Future');
+  });
 
   describe('#fork()', () => {
 

--- a/test/5.future-try.test.js
+++ b/test/5.future-try.test.js
@@ -4,6 +4,7 @@ const expect = require('chai').expect;
 const Future = require('../fluture.js');
 const FutureTry = Future.classes.FutureTry;
 const U = require('./util');
+const type = require('sanctuary-type-identifiers');
 
 describe('Future.try()', () => {
 
@@ -23,6 +24,10 @@ describe('FutureTry', () => {
 
   it('extends Future', () => {
     expect(new FutureTry).to.be.an.instanceof(Future);
+  });
+
+  it('is considered a member of fluture/Fluture', () => {
+    expect(type(new FutureTry)).to.equal('fluture/Future');
   });
 
   describe('#fork()', () => {

--- a/test/6.future-do.test.js
+++ b/test/6.future-do.test.js
@@ -4,6 +4,7 @@ const expect = require('chai').expect;
 const Future = require('../fluture.js');
 const FutureDo = Future.classes.FutureDo;
 const U = require('./util');
+const type = require('sanctuary-type-identifiers');
 
 describe('Future.do()', () => {
 
@@ -23,6 +24,10 @@ describe('FutureDo', () => {
 
   it('extends Future', () => {
     expect(new FutureDo).to.be.an.instanceof(Future);
+  });
+
+  it('is considered a member of fluture/Fluture', () => {
+    expect(type(new FutureDo)).to.equal('fluture/Future');
   });
 
   describe('#fork()', () => {


### PR DESCRIPTION
This might be considered a breaking change, since it's a feature intended for interop with Sanctuary, and I believe it will break all `S.is(Future, x)` calls.