### PR TITLE
Add fast failing to all remaining curried functions

### DIFF
--- a/fluture.js
+++ b/fluture.js
@@ -114,52 +114,15 @@
     return function partial(d){ return f(a, b, c, d) };
   }
 
-  //Creates a dispatcher for a nullary method.
-  function createNullaryDispatcher(method){
-    return function nullaryDispatch(m){
-      if(m && typeof m[method] === 'function') return m[method]();
-      return error$invalidArgument(`Future.${method}`, 1, `have a "${method}" method`, m);
-    };
-  }
-
-  //Creates a dispatcher for a unary method.
-  function createUnaryDispatcher(method){
-    return function unaryDispatch(a, m){
-      if(arguments.length === 1) return unaryPartial(unaryDispatch, a);
-      if(m && typeof m[method] === 'function') return m[method](a);
-      return error$invalidArgument(`Future.${method}`, 1, `have a "${method}" method`, m);
-    };
-  }
-
-  //Creates a dispatcher for a binary method.
-  function createBinaryDispatcher(method){
-    return function binaryDispatch(a, b, m){
-      if(arguments.length === 1) return unaryPartial(binaryDispatch, a);
-      if(arguments.length === 2) return binaryPartial(binaryDispatch, a, b);
-      if(m && typeof m[method] === 'function') return m[method](a, b);
-      return error$invalidArgument(`Future.${method}`, 2, `have a "${method}" method`, m);
-    };
-  }
-
-  //Creates a dispatcher for a binary method, but takes the object first rather than last.
-  function createInvertedBinaryDispatcher(method){
-    return function invertedBinaryDispatch(m, a, b){
-      if(arguments.length === 1) return unaryPartial(invertedBinaryDispatch, m);
-      if(arguments.length === 2) return binaryPartial(invertedBinaryDispatch, m, a);
-      if(m && typeof m[method] === 'function') return m[method](a, b);
-      return error$invalidArgument(`Future.${method}`, 0, `have a "${method}" method`, m);
-    };
-  }
-
   //Creates an error about an invalid argument.
-  function error$invalidArgument(it, at, expected, actual){
+  function invalidArgument(it, at, expected, actual){
     throw new TypeError(
       `${it} expects its ${ordinal[at]} argument to ${expected}\n  Actual: ${show(actual)}`
     );
   }
 
   //Creates an error message about a method being called with an invalid context.
-  function error$invalidContext(it, actual){
+  function invalidContext(it, actual){
     throw new TypeError(
       `${it} was invoked outside the context of a Future. You might want to use`
       + ` a dispatcher instead\n  Called on: ${show(actual)}`
@@ -171,7 +134,7 @@
   ////////////////
 
   function Future(f){
-    if(!isFunction(f)) error$invalidArgument('Future', 0, 'be a function', f);
+    if(!isFunction(f)) invalidArgument('Future', 0, 'be a function', f);
     return new SafeFuture(f);
   }
 
@@ -181,7 +144,7 @@
 
   function Future$chainRec(f, init){
     if(arguments.length === 1) return unaryPartial(Future$chainRec, f);
-    if(!isFunction(f)) error$invalidArgument('Future.chainRec', 0, 'be a function', f);
+    if(!isFunction(f)) invalidArgument('Future.chainRec', 0, 'be a function', f);
     return new ChainRec(f, init);
   }
 
@@ -192,106 +155,106 @@
   Future.prototype.of = Future$of;
 
   Future.prototype.ap = function Future$ap(m){
-    if(!isFuture(this)) error$invalidContext('Future#ap', this);
-    if(!isFuture(m)) error$invalidArgument('Future#ap', 0, 'be a Future', m);
+    if(!isFuture(this)) invalidContext('Future#ap', this);
+    if(!isFuture(m)) invalidArgument('Future#ap', 0, 'be a Future', m);
     return new FutureAp(this, m);
   };
 
   Future.prototype.map = function Future$map(f){
-    if(!isFuture(this)) error$invalidContext('Future#map', this);
-    if(!isFunction(f)) error$invalidArgument('Future#map', 0, 'be a function', f);
+    if(!isFuture(this)) invalidContext('Future#map', this);
+    if(!isFunction(f)) invalidArgument('Future#map', 0, 'be a function', f);
     return new FutureMap(this, f);
   };
 
   Future.prototype.bimap = function Future$bimap(f, g){
-    if(!isFuture(this)) error$invalidContext('Future#bimap', this);
-    if(!isFunction(f)) error$invalidArgument('Future#bimap', 0, 'be a function', f);
-    if(!isFunction(g)) error$invalidArgument('Future#bimap', 1, 'be a function', g);
+    if(!isFuture(this)) invalidContext('Future#bimap', this);
+    if(!isFunction(f)) invalidArgument('Future#bimap', 0, 'be a function', f);
+    if(!isFunction(g)) invalidArgument('Future#bimap', 1, 'be a function', g);
     return new FutureBimap(this, f, g);
   };
 
   Future.prototype.chain = function Future$chain(f){
-    if(!isFuture(this)) error$invalidContext('Future#chain', this);
-    if(!isFunction(f)) error$invalidArgument('Future#chain', 0, 'be a function', f);
+    if(!isFuture(this)) invalidContext('Future#chain', this);
+    if(!isFunction(f)) invalidArgument('Future#chain', 0, 'be a function', f);
     return new FutureChain(this, f);
   };
 
   Future.prototype.chainRej = function Future$chainRej(f){
-    if(!isFuture(this)) error$invalidContext('Future.chainRej', this);
-    if(!isFunction(f)) error$invalidArgument('Future.chainRej', 0, 'a function', f);
+    if(!isFuture(this)) invalidContext('Future.chainRej', this);
+    if(!isFunction(f)) invalidArgument('Future.chainRej', 0, 'a function', f);
     return new FutureChainRej(this, f);
   };
 
   Future.prototype.mapRej = function Future$mapRej(f){
-    if(!isFuture(this)) error$invalidContext('Future#mapRej', this);
-    if(!isFunction(f)) error$invalidArgument('Future#mapRej', 0, 'be a function', f);
+    if(!isFuture(this)) invalidContext('Future#mapRej', this);
+    if(!isFunction(f)) invalidArgument('Future#mapRej', 0, 'be a function', f);
     return new FutureMapRej(this, f);
   };
 
   Future.prototype.swap = function Future$swap(){
-    if(!isFuture(this)) error$invalidContext('Future#swap', this);
+    if(!isFuture(this)) invalidContext('Future#swap', this);
     return new FutureSwap(this);
   };
 
   Future.prototype.race = function Future$race(m){
-    if(!isFuture(this)) error$invalidContext('Future#race', this);
-    if(!isFuture(m)) error$invalidArgument('Future#race', 0, 'be a Future', m);
+    if(!isFuture(this)) invalidContext('Future#race', this);
+    if(!isFuture(m)) invalidArgument('Future#race', 0, 'be a Future', m);
     return new FutureRace(this, m);
   };
 
   Future.prototype.and = function Future$and(m){
-    if(!isFuture(this)) error$invalidContext('Future#and', this);
-    if(!isFuture(m)) error$invalidArgument('Future#and', 0, 'be a Future', m);
+    if(!isFuture(this)) invalidContext('Future#and', this);
+    if(!isFuture(m)) invalidArgument('Future#and', 0, 'be a Future', m);
     return new FutureAnd(this, m);
   };
 
   Future.prototype.or = function Future$or(m){
-    if(!isFuture(this)) error$invalidContext('Future#or', this);
-    if(!isFuture(m)) error$invalidArgument('Future#or', 0, 'be a Future', m);
+    if(!isFuture(this)) invalidContext('Future#or', this);
+    if(!isFuture(m)) invalidArgument('Future#or', 0, 'be a Future', m);
     return new FutureOr(this, m);
   };
 
   Future.prototype.both = function Future$both(m){
-    if(!isFuture(this)) error$invalidContext('Future#both', this);
-    if(!isFuture(m)) error$invalidArgument('Future#both', 0, 'be a Future', m);
+    if(!isFuture(this)) invalidContext('Future#both', this);
+    if(!isFuture(m)) invalidArgument('Future#both', 0, 'be a Future', m);
     return new FutureBoth(this, m);
   };
 
   Future.prototype.fold = function Future$fold(f, g){
-    if(!isFuture(this)) error$invalidContext('Future#fold', this);
-    if(!isFunction(f)) error$invalidArgument('Future#fold', 0, 'be a function', f);
-    if(!isFunction(g)) error$invalidArgument('Future#fold', 1, 'be a function', g);
+    if(!isFuture(this)) invalidContext('Future#fold', this);
+    if(!isFunction(f)) invalidArgument('Future#fold', 0, 'be a function', f);
+    if(!isFunction(g)) invalidArgument('Future#fold', 1, 'be a function', g);
     return new FutureFold(this, f, g);
   };
 
   Future.prototype.hook = function Future$hook(dispose, consume){
-    if(!isFuture(this)) error$invalidContext('Future#hook', this);
-    if(!isFunction(dispose)) error$invalidArgument('Future#hook', 0, 'be a function', dispose);
-    if(!isFunction(consume)) error$invalidArgument('Future#hook', 1, 'be a function', consume);
+    if(!isFuture(this)) invalidContext('Future#hook', this);
+    if(!isFunction(dispose)) invalidArgument('Future#hook', 0, 'be a function', dispose);
+    if(!isFunction(consume)) invalidArgument('Future#hook', 1, 'be a function', consume);
     return new FutureHook(this, dispose, consume);
   };
 
   Future.prototype.finally = function Future$finally(m){
-    if(!isFuture(this)) error$invalidContext('Future#finally', this);
-    if(!isFuture(m)) error$invalidArgument('Future#finally', 0, 'be a Future', m);
+    if(!isFuture(this)) invalidContext('Future#finally', this);
+    if(!isFuture(m)) invalidArgument('Future#finally', 0, 'be a Future', m);
     return new FutureFinally(this, m);
   };
 
   Future.prototype.cache = function Future$cache(){
-    if(!isFuture(this)) error$invalidContext('Future#cache', this);
+    if(!isFuture(this)) invalidContext('Future#cache', this);
     return new CachedFuture(this);
   };
 
   Future.prototype.fork = function Future$fork(rej, res){
-    if(!isFuture(this)) error$invalidContext('Future#fork', this);
-    if(!isFunction(rej)) error$invalidArgument('Future#fork', 0, 'be a function', rej);
-    if(!isFunction(res)) error$invalidArgument('Future#fork', 1, 'be a function', res);
+    if(!isFuture(this)) invalidContext('Future#fork', this);
+    if(!isFunction(rej)) invalidArgument('Future#fork', 0, 'be a function', rej);
+    if(!isFunction(res)) invalidArgument('Future#fork', 1, 'be a function', res);
     return this._f(rej, res);
   };
 
   Future.prototype.value = function Future$value(f){
-    if(!isFuture(this)) error$invalidContext('Future#value', this);
-    if(!isFunction(f)) error$invalidArgument('Future#value', 0, 'be a function', f);
+    if(!isFuture(this)) invalidContext('Future#value', this);
+    if(!isFunction(f)) invalidArgument('Future#value', 0, 'be a function', f);
     return this._f(function Future$value$rej(e){
       throw new Error(
         `Future#value was called on a rejected Future\n  Actual: Future.reject(${show(e)})`
@@ -300,7 +263,7 @@
   };
 
   Future.prototype.promise = function Future$promise(){
-    if(!isFuture(this)) error$invalidContext('Future#promise', this);
+    if(!isFuture(this)) invalidContext('Future#promise', this);
     const _this = this;
     return new Promise(function Future$promise$do(resolve, reject){
       _this._f(reject, resolve);
@@ -313,74 +276,74 @@
   Future.isFuture = isFuture;
 
   function ap$mval(mval, mfunc){
-    if(!Z.Apply.test(mfunc)) error$invalidArgument('Future.ap', 1, 'be an Apply', mfunc);
+    if(!Z.Apply.test(mfunc)) invalidArgument('Future.ap', 1, 'be an Apply', mfunc);
     return Z.ap(mval, mfunc);
   }
 
   Future.ap = function ap(mval, mfunc){
-    if(!Z.Apply.test(mval)) error$invalidArgument('Future.ap', 0, 'be an Apply', mval);
+    if(!Z.Apply.test(mval)) invalidArgument('Future.ap', 0, 'be an Apply', mval);
     if(arguments.length === 1) return unaryPartial(ap$mval, mval);
     return ap$mval(mval, mfunc);
   };
 
   function map$mapper(mapper, m){
-    if(!Z.Functor.test(m)) error$invalidArgument('Future.map', 1, 'be a Functor', m);
+    if(!Z.Functor.test(m)) invalidArgument('Future.map', 1, 'be a Functor', m);
     return Z.map(mapper, m);
   }
 
   Future.map = function map(mapper, m){
-    if(!isFunction(mapper)) error$invalidArgument('Future.map', 0, 'be a Function', mapper);
+    if(!isFunction(mapper)) invalidArgument('Future.map', 0, 'be a Function', mapper);
     if(arguments.length === 1) return unaryPartial(map$mapper, mapper);
     return map$mapper(mapper, m);
   };
 
   function bimap$lmapper$rmapper(lmapper, rmapper, m){
-    if(!Z.Bifunctor.test(m)) error$invalidArgument('Future.bimap', 2, 'be a Bifunctor', m);
+    if(!Z.Bifunctor.test(m)) invalidArgument('Future.bimap', 2, 'be a Bifunctor', m);
     return Z.bimap(lmapper, rmapper, m);
   }
 
   function bimap$lmapper(lmapper, rmapper, m){
-    if(!isFunction(rmapper)) error$invalidArgument('Future.bimap', 1, 'be a Function', rmapper);
+    if(!isFunction(rmapper)) invalidArgument('Future.bimap', 1, 'be a Function', rmapper);
     if(arguments.length === 2) return binaryPartial(bimap$lmapper$rmapper, lmapper, rmapper);
     return bimap$lmapper$rmapper(lmapper, rmapper, m);
   }
 
   Future.bimap = function bimap(lmapper, rmapper, m){
-    if(!isFunction(lmapper)) error$invalidArgument('Future.bimap', 0, 'be a Function', lmapper);
+    if(!isFunction(lmapper)) invalidArgument('Future.bimap', 0, 'be a Function', lmapper);
     if(arguments.length === 1) return unaryPartial(bimap$lmapper, lmapper);
     if(arguments.length === 2) return bimap$lmapper(lmapper, rmapper);
     return bimap$lmapper(lmapper, rmapper, m);
   };
 
   function chain$chainer(chainer, m){
-    if(!Z.Chain.test(m)) error$invalidArgument('Future.chain', 1, 'be a Chain', m);
+    if(!Z.Chain.test(m)) invalidArgument('Future.chain', 1, 'be a Chain', m);
     return Z.chain(chainer, m);
   }
 
   Future.chain = function chain(chainer, m){
-    if(!isFunction(chainer)) error$invalidArgument('Future.chain', 0, 'be a Function', chainer);
+    if(!isFunction(chainer)) invalidArgument('Future.chain', 0, 'be a Function', chainer);
     if(arguments.length === 1) return unaryPartial(chain$chainer, chainer);
     return chain$chainer(chainer, m);
   };
 
   function and$left(left, right){
-    if(!isFuture(right)) error$invalidArgument('Future.and', 1, 'be a Future', right);
+    if(!isFuture(right)) invalidArgument('Future.and', 1, 'be a Future', right);
     return new FutureAnd(left, right);
   }
 
   Future.and = function and(left, right){
-    if(!isFuture(left)) error$invalidArgument('Future.and', 0, 'be a Future', left);
+    if(!isFuture(left)) invalidArgument('Future.and', 0, 'be a Future', left);
     if(arguments.length === 1) return unaryPartial(and$left, left);
     return and$left(left, right);
   };
 
   function both$left(left, right){
-    if(!isFuture(right)) error$invalidArgument('Future.both', 1, 'be a Future', right);
+    if(!isFuture(right)) invalidArgument('Future.both', 1, 'be a Future', right);
     return new FutureBoth(left, right);
   }
 
   Future.both = function both(left, right){
-    if(!isFuture(left)) error$invalidArgument('Future.both', 0, 'be a Future', left);
+    if(!isFuture(left)) invalidArgument('Future.both', 0, 'be a Future', left);
     if(arguments.length === 1) return unaryPartial(both$left, left);
     return both$left(left, right);
   };
@@ -394,7 +357,7 @@
   }
 
   Future.after = function Future$after(n, x){
-    if(!isPositiveInteger(n)) error$invalidArgument('Future.after', 0, 'be a positive integer', n);
+    if(!isPositiveInteger(n)) invalidArgument('Future.after', 0, 'be a positive integer', n);
     if(arguments.length === 1) return unaryPartial(Future$after$n, n);
     return Future$after$n(n, x);
   };
@@ -404,7 +367,7 @@
   }
 
   Future.rejectAfter = function rejectAfter(time, reason){
-    if(!isPositiveInteger(time)) error$invalidArgument(
+    if(!isPositiveInteger(time)) invalidArgument(
       'Future.rejectAfter', 0, 'be a positive integer', time
     );
     if(arguments.length === 1) return unaryPartial(rejectAfter$time, time);
@@ -422,13 +385,13 @@
   };
 
   Future.try = function Future$try(f){
-    if(!isFunction(f)) error$invalidArgument('Future.try', 0, 'be a function', f);
+    if(!isFunction(f)) invalidArgument('Future.try', 0, 'be a function', f);
     return new FutureTry(f);
   };
 
   Future.encase = function Future$encase(f, x){
     if(arguments.length === 1) return unaryPartial(Future$encase, f);
-    if(!isFunction(f)) error$invalidArgument('Future.encase', 0, 'be a function', f);
+    if(!isFunction(f)) invalidArgument('Future.encase', 0, 'be a function', f);
     return new FutureEncase(f, x);
   };
 
@@ -437,8 +400,8 @@
       case 1: return unaryPartial(Future$encase2, f);
       case 2: return binaryPartial(Future$encase2, f, x);
       default:
-        if(!isFunction(f)) error$invalidArgument('Future.encase2', 0, 'be a function', f);
-        if(!isBinary(f)) error$invalidArgument('Future.encase2', 0, 'take two arguments', f);
+        if(!isFunction(f)) invalidArgument('Future.encase2', 0, 'be a function', f);
+        if(!isBinary(f)) invalidArgument('Future.encase2', 0, 'take two arguments', f);
         return new FutureEncase(f, x, y);
     }
   };
@@ -449,15 +412,15 @@
       case 2: return binaryPartial(Future$encase3, f, x);
       case 3: return ternaryPartial(Future$encase3, f, x, y);
       default:
-        if(!isFunction(f)) error$invalidArgument('Future.encase3', 0, 'be a function', f);
-        if(!isTernary(f)) error$invalidArgument('Future.encase3', 0, 'take three arguments', f);
+        if(!isFunction(f)) invalidArgument('Future.encase3', 0, 'be a function', f);
+        if(!isTernary(f)) invalidArgument('Future.encase3', 0, 'take three arguments', f);
         return new FutureEncase(f, x, y, z);
     }
   };
 
   Future.fromPromise = function Future$fromPromise(f, x){
     if(arguments.length === 1) return unaryPartial(Future$fromPromise, f);
-    if(!isFunction(f)) error$invalidArgument('Future.fromPromise', 0, 'be a function', f);
+    if(!isFunction(f)) invalidArgument('Future.fromPromise', 0, 'be a function', f);
     return new FutureFromPromise(f, x);
   };
 
@@ -466,8 +429,8 @@
       case 1: return unaryPartial(Future$fromPromise2, f);
       case 2: return binaryPartial(Future$fromPromise2, f, x);
       default:
-        if(!isFunction(f)) error$invalidArgument('Future.fromPromise2', 0, 'be a function', f);
-        if(!isBinary(f)) error$invalidArgument('Future.fromPromise2', 0, 'take two arguments', f);
+        if(!isFunction(f)) invalidArgument('Future.fromPromise2', 0, 'be a function', f);
+        if(!isBinary(f)) invalidArgument('Future.fromPromise2', 0, 'take two arguments', f);
         return new FutureFromPromise(f, x, y);
     }
   };
@@ -479,46 +442,178 @@
       case 3: return ternaryPartial(Future$fromPromise3, f, x, y);
       default:
         if(!isFunction(f))
-          error$invalidArgument('Future.fromPromise3', 0, 'be a function', f);
+          invalidArgument('Future.fromPromise3', 0, 'be a function', f);
         if(!isTernary(f))
-          error$invalidArgument('Future.fromPromise3', 0, 'take three arguments', f);
+          invalidArgument('Future.fromPromise3', 0, 'take three arguments', f);
         return new FutureFromPromise(f, x, y, z);
     }
   };
 
   Future.node = function Future$node(f){
-    if(!isFunction(f)) error$invalidArgument('Future.node', 0, 'be a function', f);
+    if(!isFunction(f)) invalidArgument('Future.node', 0, 'be a function', f);
     return new FutureNode(f);
   };
 
-  Future.parallel = function Future$parallel(i, ms){
-    if(arguments.length === 1) return unaryPartial(Future$parallel, i);
-    if(!isPositiveInteger(i))
-      error$invalidArgument('Future.parallel', 0, 'be a positive integer', i);
-    if(!Array.isArray(ms))
-      error$invalidArgument('Future.parallel', 1, 'be an array', ms);
+  function parallel$i(i, ms){
+    if(!Array.isArray(ms)) invalidArgument('Future.parallel', 1, 'be an array', ms);
     return new FutureParallel(i, ms);
+  }
+
+  Future.parallel = function parallel(i, ms){
+    if(!isPositiveInteger(i)) invalidArgument('Future.parallel', 0, 'be a positive integer', i);
+    if(arguments.length === 1) return unaryPartial(parallel$i, i);
+    return parallel$i(i, ms);
   };
 
   Future.do = function Future$do(f){
-    if(!isFunction(f)) error$invalidArgument('Future.do', 0, 'be a function', f);
+    if(!isFunction(f)) invalidArgument('Future.do', 0, 'be a function', f);
     return new FutureDo(f);
   };
 
-  Future.chainRej = createUnaryDispatcher('chainRej');
-  Future.mapRej = createUnaryDispatcher('mapRej');
-  Future.swap = createNullaryDispatcher('swap');
-  Future.fork = createBinaryDispatcher('fork');
-  Future.race = createUnaryDispatcher('race');
-  Future.or = createUnaryDispatcher('or');
-  Future.fold = createBinaryDispatcher('fold');
-  Future.hook = createInvertedBinaryDispatcher('hook');
-  Future.finally = createUnaryDispatcher('finally');
-  Future.value = createUnaryDispatcher('value');
-  Future.promise = createNullaryDispatcher('promise');
-  Future.cache = createNullaryDispatcher('cache');
-  Future.extractLeft = createNullaryDispatcher('extractLeft');
-  Future.extractRight = createNullaryDispatcher('extractRight');
+  function chainRej$chainer(chainer, m){
+    if(!isFuture(m)) invalidArgument('Future.chainRej', 1, 'be a Future', m);
+    return new FutureChainRej(m, chainer);
+  }
+
+  Future.chainRej = function chainRej(chainer, m){
+    if(!isFunction(chainer)) invalidArgument('Future.chainRej', 0, 'be a Function', chainer);
+    if(arguments.length === 1) return unaryPartial(chainRej$chainer, chainer);
+    return chainRej$chainer(chainer, m);
+  };
+
+  function mapRej$mapper(mapper, m){
+    if(!isFuture(m)) invalidArgument('Future.mapRej', 1, 'be a Future', m);
+    return new FutureMapRej(m, mapper);
+  }
+
+  Future.mapRej = function mapRej(mapper, m){
+    if(!isFunction(mapper)) invalidArgument('Future.mapRej', 0, 'be a Function', mapper);
+    if(arguments.length === 1) return unaryPartial(mapRej$mapper, mapper);
+    return mapRej$mapper(mapper, m);
+  };
+
+  function race$right(right, left){
+    if(!isFuture(left)) invalidArgument('Future.race', 1, 'be a Future', left);
+    return new FutureRace(left, right);
+  }
+
+  Future.race = function race(right, left){
+    if(!isFuture(right)) invalidArgument('Future.race', 0, 'be a Future', right);
+    if(arguments.length === 1) return unaryPartial(race$right, right);
+    return race$right(right, left);
+  };
+
+  function or$right(right, left){
+    if(!isFuture(left)) invalidArgument('Future.or', 1, 'be a Future', left);
+    return new FutureOr(left, right);
+  }
+
+  Future.or = function or(right, left){
+    if(!isFuture(right)) invalidArgument('Future.or', 0, 'be a Future', right);
+    if(arguments.length === 1) return unaryPartial(or$right, right);
+    return or$right(right, left);
+  };
+
+  function finally$right(right, left){
+    if(!isFuture(left)) invalidArgument('Future.finally', 1, 'be a Future', left);
+    return new FutureFinally(left, right);
+  }
+
+  Future.finally = function finally$(right, left){
+    if(!isFuture(right)) invalidArgument('Future.finally', 0, 'be a Future', right);
+    if(arguments.length === 1) return unaryPartial(finally$right, right);
+    return finally$right(right, left);
+  };
+
+  function value$cont(cont, m){
+    if(!isFuture(m)) invalidArgument('Future.value', 1, 'be a Future', m);
+    return m.value(cont);
+  }
+
+  Future.value = function value(cont, m){
+    if(!isFunction(cont)) invalidArgument('Future.value', 0, 'be a Function', cont);
+    if(arguments.length === 1) return unaryPartial(value$cont, cont);
+    return value$cont(cont, m);
+  };
+
+  Future.swap = function swap(m){
+    if(!isFuture(m)) invalidArgument('Future.swap', 0, 'be a Future', m);
+    return new FutureSwap(m);
+  };
+
+  Future.promise = function promise(m){
+    if(!isFuture(m)) invalidArgument('Future.promise', 0, 'be a Future', m);
+    return m.promise();
+  };
+
+  Future.cache = function cache(m){
+    if(!isFuture(m)) invalidArgument('Future.cache', 0, 'be a Future', m);
+    return new CachedFuture(m);
+  };
+
+  Future.extractLeft = function extractLeft(m){
+    if(!isFuture(m)) invalidArgument('Future.extractLeft', 0, 'be a Future', m);
+    return m.extractLeft();
+  };
+
+  Future.extractRight = function extractRight(m){
+    if(!isFuture(m)) invalidArgument('Future.extractRight', 0, 'be a Future', m);
+    return m.extractRight();
+  };
+
+  function fork$f$g(f, g, m){
+    if(!isFuture(m)) invalidArgument('Future.fork', 2, 'be a Future', m);
+    return m._f(f, g);
+  }
+
+  function fork$f(f, g, m){
+    if(!isFunction(g)) invalidArgument('Future.fork', 1, 'be a function', g);
+    if(arguments.length === 2) return binaryPartial(fork$f$g, f, g);
+    return fork$f$g(f, g, m);
+  }
+
+  Future.fork = function fork(f, g, m){
+    if(!isFunction(f)) invalidArgument('Future.fork', 0, 'be a function', f);
+    if(arguments.length === 1) return unaryPartial(fork$f, f);
+    if(arguments.length === 2) return fork$f(f, g);
+    return fork$f(f, g, m);
+  };
+
+  function fold$f$g(f, g, m){
+    if(!isFuture(m)) invalidArgument('Future.fold', 2, 'be a Future', m);
+    return new FutureFold(m, f, g);
+  }
+
+  function fold$f(f, g, m){
+    if(!isFunction(g)) invalidArgument('Future.fold', 1, 'be a function', g);
+    if(arguments.length === 2) return binaryPartial(fold$f$g, f, g);
+    return fold$f$g(f, g, m);
+  }
+
+  Future.fold = function fold(f, g, m){
+    if(!isFunction(f)) invalidArgument('Future.fold', 0, 'be a function', f);
+    if(arguments.length === 1) return unaryPartial(fold$f, f);
+    if(arguments.length === 2) return fold$f(f, g);
+    return fold$f(f, g, m);
+  };
+
+  function hook$acquire$cleanup(acquire, cleanup, consume){
+    if(!isFunction(consume)) invalidArgument('Future.hook', 2, 'be a Future', consume);
+    return new FutureHook(acquire, cleanup, consume);
+  }
+
+  function hook$acquire(acquire, cleanup, consume){
+    if(!isFunction(cleanup)) invalidArgument('Future.hook', 1, 'be a function', cleanup);
+    if(arguments.length === 2) return binaryPartial(hook$acquire$cleanup, acquire, cleanup);
+    return hook$acquire$cleanup(acquire, cleanup, consume);
+  }
+
+  Future.hook = function hook(acquire, cleanup, consume){
+    if(!isFuture(acquire)) invalidArgument('Future.hook', 0, 'be a Future', acquire);
+    if(arguments.length === 1) return unaryPartial(hook$acquire, acquire);
+    if(arguments.length === 2) return hook$acquire(acquire, cleanup);
+    return hook$acquire(acquire, cleanup, consume);
+  };
 
   //Utilities.
   Future.util = {
@@ -931,7 +1026,7 @@
   //----------
 
   function check$do$g(g){
-    if(!isIterator(g)) error$invalidArgument(
+    if(!isIterator(g)) invalidArgument(
       'Future.do', 0, 'return an iterator, maybe you forgot the "*"', g
     );
   }

--- a/test/1.future.test.js
+++ b/test/1.future.test.js
@@ -281,19 +281,31 @@ describe('Future', () => {
       expect(Future.fork(U.noop, U.noop)).to.be.a('function');
     });
 
-    it('throws when not given a Future', () => {
-      const f = () => Future.fork(U.noop)(U.noop)(1);
-      expect(f).to.throw(TypeError, /Future/);
+    it('throws when not given a Function as first argument', () => {
+      const f = () => Future.fork(1);
+      expect(f).to.throw(TypeError, /Future.*first/);
     });
 
-    it('dispatches to #fork()', done => {
+    it('throws when not given a Function as second argument', () => {
+      const f = () => Future.fork(U.add(1), 1);
+      expect(f).to.throw(TypeError, /Future.*second/);
+    });
+
+    it('throws when not given a Future as third argument', () => {
+      const f = () => Future.fork(U.add(1), U.add(1), 1);
+      expect(f).to.throw(TypeError, /Future.*third/);
+    });
+
+    it('dispatches to #_f()', done => {
       const a = () => {};
       const b = () => {};
-      Future.fork(a, b, {fork: (x, y) => {
+      const mock = Object.create(F.mock);
+      mock._f = (x, y) => {
         expect(x).to.equal(a);
         expect(y).to.equal(b);
         done();
-      }});
+      };
+      Future.fork(a, b, mock);
     });
 
   });
@@ -306,17 +318,24 @@ describe('Future', () => {
       expect(Future.value(U.noop)).to.be.a('function');
     });
 
-    it('throws when not given a Future', () => {
-      const f = () => Future.value(U.noop)(1);
-      expect(f).to.throw(TypeError, /Future/);
+    it('throws when not given a Function as first argument', () => {
+      const f = () => Future.value(1);
+      expect(f).to.throw(TypeError, /Future.*first/);
+    });
+
+    it('throws when not given a Future as second argument', () => {
+      const f = () => Future.value(U.add(1), 1);
+      expect(f).to.throw(TypeError, /Future.*second/);
     });
 
     it('dispatches to #value()', done => {
       const a = () => {};
-      Future.value(a, {value: x => {
+      const mock = Object.create(F.mock);
+      mock.value = x => {
         expect(x).to.equal(a);
         done();
-      }});
+      };
+      Future.value(a, mock);
     });
 
   });
@@ -329,7 +348,9 @@ describe('Future', () => {
     });
 
     it('dispatches to #promise', done => {
-      Future.promise({promise: done});
+      const mock = Object.create(F.mock);
+      mock.promise = done;
+      Future.promise(mock);
     });
 
   });
@@ -342,7 +363,9 @@ describe('Future', () => {
     });
 
     it('dispatches to #extractLeft', done => {
-      Future.extractLeft({extractLeft: done});
+      const mock = Object.create(F.mock);
+      mock.extractLeft = done;
+      Future.extractLeft(mock);
     });
 
   });
@@ -355,7 +378,9 @@ describe('Future', () => {
     });
 
     it('dispatches to #extractRight', done => {
-      Future.extractRight({extractRight: done});
+      const mock = Object.create(F.mock);
+      mock.extractRight = done;
+      Future.extractRight(mock);
     });
 
   });

--- a/test/5.future-ap.test.js
+++ b/test/5.future-ap.test.js
@@ -2,9 +2,71 @@
 
 const expect = require('chai').expect;
 const Future = require('../fluture.js');
-const FutureAp = Future.classes.FutureAp;
 const U = require('./util');
 const F = require('./futures');
+
+const testInstance = ap => {
+
+  describe('#fork()', () => {
+
+    it('calls the function contained in the given Future to its contained value', () => {
+      const actual = ap(Future.of(1), Future.of(U.add(1)));
+      return U.assertResolved(actual, 2);
+    });
+
+    it('rejects if one of the two reject', () => {
+      const left = ap(Future.reject('err'), Future.of(1));
+      const right = ap(Future.of(U.add(1)), Future.reject('err'));
+      return Promise.all([
+        U.assertRejected(left, 'err'),
+        U.assertRejected(right, 'err')
+      ]);
+    });
+
+    it('does not matter if the left resolves late', () => {
+      const actual = ap(Future.after(20, 1), Future.of(U.add(1)));
+      return U.assertResolved(actual, 2);
+    });
+
+    it('does not matter if the right resolves late', () => {
+      const actual = ap(Future.of(1), Future.after(20, U.add(1)));
+      return U.assertResolved(actual, 2);
+    });
+
+    it('forks in sequence', done => {
+      let running = true;
+      const left = Future.after(20, 1).map(x => { running = false; return x });
+      const right = Future.of(_ => { expect(running).to.equal(false); done() });
+      ap(left, right).fork(U.noop, U.noop);
+    });
+
+    it('cancels the left Future if cancel is called while it is running', done => {
+      const left = Future(() => () => done());
+      const right = Future.after(20, U.add(1));
+      const cancel = ap(left, right).fork(U.noop, U.noop);
+      cancel();
+    });
+
+    it('cancels the right Future if cancel is called while it is running', done => {
+      const left = Future.of(1);
+      const right = Future(() => () => done());
+      const cancel = ap(left, right).fork(U.noop, U.noop);
+      cancel();
+    });
+
+  });
+
+  describe('#toString()', () => {
+
+    it('returns the code to create the FutureAp', () => {
+      const m = ap(Future.of(1), Future.of(x => x));
+      const s = 'Future.of(1).ap(Future.of(x => x))';
+      expect(m.toString()).to.equal(s);
+    });
+
+  });
+
+};
 
 describe('Future.ap()', () => {
 
@@ -24,10 +86,7 @@ describe('Future.ap()', () => {
     expect(f).to.throw(TypeError, /Future.*second/);
   });
 
-  it('returns a FutureAp', () => {
-    const actual = Future.ap(Future.of(1), Future.of(U.add(1)));
-    expect(actual).to.be.an.instanceof(Future.classes.FutureAp);
-  });
+  testInstance((a, b) => Future.ap(b, a));
 
 });
 
@@ -50,75 +109,6 @@ describe('Future#ap()', () => {
     fs.forEach(f => expect(f).to.throw(TypeError, /Future/));
   });
 
-  it('returns an instance of FutureAp', () => {
-    expect(F.resolved.ap(F.resolved)).to.be.an.instanceof(FutureAp);
-  });
-
-});
-
-describe('FutureAp', () => {
-
-  it('extends Future', () => {
-    expect(new FutureAp).to.be.an.instanceof(Future);
-  });
-
-  describe('#fork()', () => {
-
-    it('calls the function contained in the given Future to its contained value', () => {
-      const actual = Future.of(1).ap(Future.of(U.add(1)));
-      return U.assertResolved(actual, 2);
-    });
-
-    it('rejects if one of the two reject', () => {
-      const left = Future.reject('err').ap(Future.of(1));
-      const right = Future.of(U.add(1)).ap(Future.reject('err'));
-      return Promise.all([
-        U.assertRejected(left, 'err'),
-        U.assertRejected(right, 'err')
-      ]);
-    });
-
-    it('does not matter if the left resolves late', () => {
-      const actual = Future.after(20, 1).ap(Future.of(U.add(1)));
-      return U.assertResolved(actual, 2);
-    });
-
-    it('does not matter if the right resolves late', () => {
-      const actual = Future.of(1).ap(Future.after(20, U.add(1)));
-      return U.assertResolved(actual, 2);
-    });
-
-    it('forks in sequence', done => {
-      let running = true;
-      const left = Future.after(20, 1).map(x => { running = false; return x });
-      const right = Future.of(_ => { expect(running).to.equal(false); done() });
-      left.ap(right).fork(U.noop, U.noop);
-    });
-
-    it('cancels the left Future if cancel is called while it is running', done => {
-      const left = Future(() => () => done());
-      const right = Future.after(20, U.add(1));
-      const cancel = left.ap(right).fork(U.noop, U.noop);
-      cancel();
-    });
-
-    it('cancels the right Future if cancel is called while it is running', done => {
-      const left = Future.of(1);
-      const right = Future(() => () => done());
-      const cancel = left.ap(right).fork(U.noop, U.noop);
-      cancel();
-    });
-
-  });
-
-  describe('#toString()', () => {
-
-    it('returns the code to create the FutureAp', () => {
-      const m = Future.of(1).ap(Future.of(x => x));
-      const s = 'Future.of(1).ap(Future.of(x => x))';
-      expect(m.toString()).to.equal(s);
-    });
-
-  });
+  testInstance((a, b) => a.ap(b));
 
 });

--- a/test/5.future-bimap.test.js
+++ b/test/5.future-bimap.test.js
@@ -2,9 +2,35 @@
 
 const expect = require('chai').expect;
 const Future = require('../fluture.js');
-const FutureBimap = Future.classes.FutureBimap;
 const U = require('./util');
-const F = require('./futures');
+
+const testInstance = bimap => {
+
+  describe('#fork()', () => {
+
+    it('applies the first function to the value in the rejection branch', () => {
+      const actual = bimap(Future.reject(1), U.add(1), U.failRes);
+      return U.assertRejected(actual, 2);
+    });
+
+    it('applies the second function to the value in the resolution branch', () => {
+      const actual = bimap(Future.of(1), U.failRej, U.add(1));
+      return U.assertResolved(actual, 2);
+    });
+
+  });
+
+  describe('#toString()', () => {
+
+    it('returns the code to create the FutureBimap', () => {
+      const m = bimap(Future.of(1), x => x, y => y);
+      const s = 'Future.of(1).bimap(x => x, y => y)';
+      expect(m.toString()).to.equal(s);
+    });
+
+  });
+
+};
 
 describe('Future.bimap()', () => {
 
@@ -31,10 +57,7 @@ describe('Future.bimap()', () => {
     expect(f).to.throw(TypeError, /Future.*third/);
   });
 
-  it('returns a FutureBimap', () => {
-    const actual = Future.bimap(U.add(1), U.add(1), Future.of(1));
-    expect(actual).to.be.an.instanceof(Future.classes.FutureBimap);
-  });
+  testInstance((m, f, g) => Future.bimap(f, g, m));
 
 });
 
@@ -57,40 +80,6 @@ describe('Future#bimap()', () => {
     fs.forEach(f => expect(f).to.throw(TypeError, /Future/));
   });
 
-  it('returns an instance of FutureBimap', () => {
-    expect(F.resolved.bimap(U.bang, U.bang)).to.be.an.instanceof(FutureBimap);
-  });
-
-});
-
-describe('FutureBimap', () => {
-
-  it('extends Future', () => {
-    expect(new FutureBimap).to.be.an.instanceof(Future);
-  });
-
-  describe('#fork()', () => {
-
-    it('applies the first function to the value in the rejection branch', () => {
-      const actual = Future.reject(1).bimap(U.add(1), U.failRes);
-      return U.assertRejected(actual, 2);
-    });
-
-    it('applies the second function to the value in the resolution branch', () => {
-      const actual = Future.of(1).bimap(U.failRej, U.add(1));
-      return U.assertResolved(actual, 2);
-    });
-
-  });
-
-  describe('#toString()', () => {
-
-    it('returns the code to create the FutureBimap', () => {
-      const m = Future.of(1).bimap(x => x, y => y);
-      const s = 'Future.of(1).bimap(x => x, y => y)';
-      expect(m.toString()).to.equal(s);
-    });
-
-  });
+  testInstance((m, f, g) => m.bimap(f, g));
 
 });

--- a/test/5.future-encase.test.js
+++ b/test/5.future-encase.test.js
@@ -36,6 +36,7 @@ describe('Future.encase2()', () => {
     expect(Future.encase2.length).to.equal(3);
     expect(Future.encase2((a, b) => b)).to.be.a('function');
     expect(Future.encase2((a, b) => b)(1)).to.be.a('function');
+    expect(Future.encase2((a, b) => b, 1)).to.be.a('function');
   });
 
   it('throws TypeError when not given a binary function', () => {

--- a/test/5.future-from-promise.test.js
+++ b/test/5.future-from-promise.test.js
@@ -36,6 +36,7 @@ describe('Future.fromPromise2()', () => {
     expect(Future.fromPromise2.length).to.equal(3);
     expect(Future.fromPromise2((a, b) => b)).to.be.a('function');
     expect(Future.fromPromise2((a, b) => b)(1)).to.be.a('function');
+    expect(Future.fromPromise2((a, b) => b, 1)).to.be.a('function');
   });
 
   it('throws TypeError when not given a binary function', () => {

--- a/test/5.future-hook.test.js
+++ b/test/5.future-hook.test.js
@@ -2,9 +2,95 @@
 
 const expect = require('chai').expect;
 const Future = require('../fluture.js');
-const FutureHook = Future.classes.FutureHook;
 const U = require('./util');
 const F = require('./futures');
+
+const testInstance = hook => {
+
+  describe('#fork()', () => {
+
+    const m = F.resolved, xs = [NaN, {}, [], 1, 'a', new Date, undefined, null];
+
+    it('throws when the first function does not return Future', () => {
+      const fs = xs.map(x => () => hook(m, () => x, () => m).fork(U.noop, U.noop));
+      fs.forEach(f => expect(f).to.throw(TypeError, /Future/));
+    });
+
+    it('throws when the second function does not return Future', () => {
+      const fs = xs.map(x => () => hook(m, () => m, () => x).fork(U.noop, U.noop));
+      fs.forEach(f => expect(f).to.throw(TypeError, /Future/));
+    });
+
+    it('runs the first computation after the second, both with the resource', done => {
+      let ran = false;
+      hook(m,
+        x => {
+          expect(x).to.equal('resolved');
+          return Future((rej, res) => res(done(ran ? null : new Error('Second did not run'))));
+        },
+        x => {
+          expect(x).to.equal('resolved');
+          return Future((rej, res) => res(ran = true));
+        }
+      ).fork(done, U.noop);
+    });
+
+    it('runs the first even if the second rejects', done => {
+      hook(m,
+        _ => Future(_ => done()),
+        _ => Future.reject(2)
+      ).fork(U.noop, U.noop);
+    });
+
+    it('rejects with the rejection reason of the first', () => {
+      const rejected = hook(m, _ => Future.reject(1), _ => Future.reject(2));
+      const resolved = hook(m, _ => Future.reject(1), _ => Future.of(2));
+      return Promise.all([
+        U.assertRejected(rejected, 1),
+        U.assertRejected(resolved, 1)
+      ]);
+    });
+
+    it('assumes the state of the second if the first resolves', () => {
+      const rejected = hook(m, _ => Future.of(1), _ => Future.reject(2));
+      const resolved = hook(m, _ => Future.of(1), _ => Future.of(2));
+      return Promise.all([
+        U.assertRejected(rejected, 2),
+        U.assertResolved(resolved, 2)
+      ]);
+    });
+
+    it('does not hook after being cancelled', done => {
+      hook(F.resolvedSlow, _ => Future.of('clean'), U.failRes).fork(U.failRej, U.failRes)();
+      setTimeout(done, 25);
+    });
+
+    it('does not reject after being cancelled', done => {
+      hook(F.rejectedSlow, _ => Future.of('clean'), U.failRes).fork(U.failRej, U.failRes)();
+      hook(F.resolved, _ => Future.of('clean'), () => F.rejectedSlow).fork(U.failRej, U.failRes)();
+      setTimeout(done, 25);
+    });
+
+    it('immediately runs and cancels the disposal Future when cancelled after acquire', done => {
+      const cancel =
+        hook(F.resolved, _ => Future(() => () => done()), () => F.resolvedSlow)
+        .fork(U.failRej, U.failRes);
+      setTimeout(cancel, 10);
+    });
+
+  });
+
+  describe('#toString()', () => {
+
+    it('returns the code to create the FutureHook', () => {
+      const m = hook(Future.of(1), () => Future.of(2), () => Future.of(3));
+      const s = 'Future.of(1).hook(() => Future.of(2), () => Future.of(3))';
+      expect(m.toString()).to.equal(s);
+    });
+
+  });
+
+};
 
 describe('Future.hook()', () => {
 
@@ -12,17 +98,26 @@ describe('Future.hook()', () => {
     expect(Future.hook).to.be.a('function');
     expect(Future.hook.length).to.equal(3);
     expect(Future.hook(Future.of(1))).to.be.a('function');
+    expect(Future.hook(Future.of(1))(U.noop)).to.be.a('function');
     expect(Future.hook(Future.of(1), U.noop)).to.be.a('function');
   });
 
-  it('throws when not given a Future', () => {
-    const f = () => Future.hook(1)(U.noop)(U.noop);
-    expect(f).to.throw(TypeError, /Future/);
+  it('throws when not given a Future as first argument', () => {
+    const f = () => Future.hook(1);
+    expect(f).to.throw(TypeError, /Future.*first/);
   });
 
-  it('returns an instance of FutureHook', () => {
-    expect(Future.hook(F.resolved, U.noop, U.noop)).to.be.an.instanceof(FutureHook);
+  it('throws when not given a Function as second argument', () => {
+    const f = () => Future.hook(Future.of(1), 1);
+    expect(f).to.throw(TypeError, /Future.*second/);
   });
+
+  it('throws when not given a Function as third argument', () => {
+    const f = () => Future.hook(Future.of(1), U.add(1), 1);
+    expect(f).to.throw(TypeError, /Future.*third/);
+  });
+
+  testInstance((m, f, g) => Future.hook(m, f, g));
 
 });
 
@@ -45,99 +140,6 @@ describe('Future#hook()', () => {
     fs.forEach(f => expect(f).to.throw(TypeError, /Future/));
   });
 
-  it('returns an instance of FutureHook', () => {
-    expect(F.resolved.hook(U.noop, U.noop)).to.be.an.instanceof(FutureHook);
-  });
-
-});
-
-describe('FutureHook', () => {
-
-  it('extends Future', () => {
-    expect(new FutureHook).to.be.an.instanceof(Future);
-  });
-
-  describe('#fork()', () => {
-
-    const m = F.resolved, xs = [NaN, {}, [], 1, 'a', new Date, undefined, null];
-
-    it('throws when the first function does not return Future', () => {
-      const fs = xs.map(x => () => m.hook(() => x, () => m).fork(U.noop, U.noop));
-      fs.forEach(f => expect(f).to.throw(TypeError, /Future/));
-    });
-
-    it('throws when the second function does not return Future', () => {
-      const fs = xs.map(x => () => m.hook(() => m, () => x).fork(U.noop, U.noop));
-      fs.forEach(f => expect(f).to.throw(TypeError, /Future/));
-    });
-
-    it('runs the first computation after the second, both with the resource', done => {
-      let ran = false;
-      m.hook(
-        x => {
-          expect(x).to.equal('resolved');
-          return Future((rej, res) => res(done(ran ? null : new Error('Second did not run'))));
-        },
-        x => {
-          expect(x).to.equal('resolved');
-          return Future((rej, res) => res(ran = true));
-        }
-      ).fork(done, U.noop);
-    });
-
-    it('runs the first even if the second rejects', done => {
-      m.hook(
-        _ => Future(_ => done()),
-        _ => Future.reject(2)
-      ).fork(U.noop, U.noop);
-    });
-
-    it('rejects with the rejection reason of the first', () => {
-      const rejected = m.hook(_ => Future.reject(1), _ => Future.reject(2));
-      const resolved = m.hook(_ => Future.reject(1), _ => Future.of(2));
-      return Promise.all([
-        U.assertRejected(rejected, 1),
-        U.assertRejected(resolved, 1)
-      ]);
-    });
-
-    it('assumes the state of the second if the first resolves', () => {
-      const rejected = m.hook(_ => Future.of(1), _ => Future.reject(2));
-      const resolved = m.hook(_ => Future.of(1), _ => Future.of(2));
-      return Promise.all([
-        U.assertRejected(rejected, 2),
-        U.assertResolved(resolved, 2)
-      ]);
-    });
-
-    it('does not hook after being cancelled', done => {
-      F.resolvedSlow.hook(_ => Future.of('cleanup'), U.failRes).fork(U.failRej, U.failRes)();
-      setTimeout(done, 25);
-    });
-
-    it('does not reject after being cancelled', done => {
-      F.rejectedSlow.hook(_ => Future.of('cleanup'), U.failRes).fork(U.failRej, U.failRes)();
-      F.resolved.hook(_ => Future.of('cleanup'), () => F.rejectedSlow).fork(U.failRej, U.failRes)();
-      setTimeout(done, 25);
-    });
-
-    it('immediately runs and cancels the disposal Future when cancelled after acquire', done => {
-      const cancel = F.resolved
-        .hook(_ => Future(() => () => done()), () => F.resolvedSlow)
-        .fork(U.failRej, U.failRes);
-      setTimeout(cancel, 10);
-    });
-
-  });
-
-  describe('#toString()', () => {
-
-    it('returns the code to create the FutureHook', () => {
-      const m = Future.of(1).hook(() => Future.of(2), () => Future.of(3));
-      const s = 'Future.of(1).hook(() => Future.of(2), () => Future.of(3))';
-      expect(m.toString()).to.equal(s);
-    });
-
-  });
+  testInstance((m, f, g) => m.hook(f, g));
 
 });

--- a/test/5.future-swap.test.js
+++ b/test/5.future-swap.test.js
@@ -2,9 +2,35 @@
 
 const expect = require('chai').expect;
 const Future = require('../fluture.js');
-const FutureSwap = Future.classes.FutureSwap;
 const U = require('./util');
-const F = require('./futures');
+
+const testInstance = swap => {
+
+  describe('#fork()', () => {
+
+    it('rejects with the resolution value', () => {
+      const actual = swap(Future.of(1));
+      return U.assertRejected(actual, 1);
+    });
+
+    it('resolves with the rejection reason', () => {
+      const actual = swap(Future.reject(1));
+      return U.assertResolved(actual, 1);
+    });
+
+  });
+
+  describe('#toString()', () => {
+
+    it('returns the code to create the FutureSwap', () => {
+      const m = swap(Future.of(1));
+      const s = 'Future.of(1).swap()';
+      expect(m.toString()).to.equal(s);
+    });
+
+  });
+
+};
 
 describe('Future.swap()', () => {
 
@@ -13,9 +39,7 @@ describe('Future.swap()', () => {
     expect(f).to.throw(TypeError, /Future/);
   });
 
-  it('returns an instance of FutureSwap', () => {
-    expect(Future.swap(F.resolved)).to.be.an.instanceof(FutureSwap);
-  });
+  testInstance(m => Future.swap(m));
 
 });
 
@@ -26,40 +50,6 @@ describe('Future#swap()', () => {
     expect(f).to.throw(TypeError, /Future/);
   });
 
-  it('returns an instance of FutureSwap', () => {
-    expect(F.resolved.swap()).to.be.an.instanceof(FutureSwap);
-  });
-
-});
-
-describe('FutureSwap', () => {
-
-  it('extends Future', () => {
-    expect(new FutureSwap).to.be.an.instanceof(Future);
-  });
-
-  describe('#fork()', () => {
-
-    it('rejects with the resolution value', () => {
-      const actual = Future.of(1).swap();
-      return U.assertRejected(actual, 1);
-    });
-
-    it('resolves with the rejection reason', () => {
-      const actual = Future.reject(1).swap();
-      return U.assertResolved(actual, 1);
-    });
-
-  });
-
-  describe('#toString()', () => {
-
-    it('returns the code to create the FutureSwap', () => {
-      const m = Future.of(1).swap();
-      const s = 'Future.of(1).swap()';
-      expect(m.toString()).to.equal(s);
-    });
-
-  });
+  testInstance(m => m.swap());
 
 });

--- a/test/util.js
+++ b/test/util.js
@@ -8,6 +8,7 @@ const AssertionError = require('assert').AssertionError;
 exports.STACKSIZE = (function r(){try{return 1 + r()}catch(e){return 1}}());
 exports.noop = () => {};
 exports.add = a => b => a + b;
+exports.sub = a => b => a - b;
 exports.bang = s => `${s}!`;
 exports.B = f => g => x => f(g(x));
 exports.error = new Error('Intentional error for unit testing');


### PR DESCRIPTION
> Finally finally closes #4

I've reverted the commits involved in #66 because it broke multiple of the affected functions. The reason some of the functions broke is because of arguments being passed into class constructors in the wrong order. The reason this wasn't caught by unit-tests is because all I'm asserting for the static constructors, is that they return the expected class instance. The actual test of the class instances themselves use instances created by methods (rather than the static functions affected in this commit).

Now I'm reluctant to merge this until I know that these kind of mistakes would be caught by the unit tests. Maybe I should run all instance tests on several instances, each created in a different way. For now that means that most instance tests would run twice.