### PR TITLE
Flip the argument order of fluent `ap`

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,12 +103,10 @@ For front-end applications and node <v4, please use `require('fluture/es5')`.
 [<img src="https://raw.github.com/fantasyland/fantasy-land/master/logo.png" align="right" width="82" height="82" alt="Fantasy Land" />][FL]
 [<img src="https://raw.githubusercontent.com/rpominov/static-land/master/logo/logo.png" align="right" height="82" alt="Static Land" />][6]
 
-* `Future` implements [Fantasy Land 1][FL1], [Fantasy Land 2][FL2],
-  [Fantasy Land 3][FL3], and [Static Land][6] -compatible `Bifunctor`, `Monad`
-  and `ChainRec` (`of`, `ap`, `map`, `bimap`, `chain`, `chainRec`). Fantasy Land
-  0.x is *mostly* supported. Everything but `Apply` (`ap`) is, this means that
-  dispatchers to Fantasy Land 0.x `ap` (like the one in Ramda) will not work.
-* `Future.Par` implements [Fantasy Land 3][FL3] `Alternative` (`of`, `zero`, `map`, `ap`, `alt`).
+* `Future` implements [Fantasy Land][FL] and [Static Land][6] -compatible
+  `Bifunctor`, `Monad` and `ChainRec` (`of`, `ap`, `map`, `bimap`, `chain`, `chainRec`).
+  All versions of Fantasy Land are supported.
+* `Future.Par` implements [Fantasy Land 3][FL] `Alternative` (`of`, `zero`, `map`, `ap`, `alt`).
 * The Future representative contains a `@@type` property for [Sanctuary Type Identifiers][STI].
 
 ## Documentation
@@ -378,20 +376,24 @@ you chain more over the same structure. It's therefore recommended that you use
 traverse a large list (10000+ items).
 
 #### ap
-##### `#ap :: Future a b ~> Future a (b -> c) -> Future a c`
+##### `#ap :: Future a (b -> c) ~> Future a b -> Future a c`
 ##### `.ap :: Apply m => m (a -> b) -> m a -> m b`
 
-Applies the function contained in the right-hand Future or Apply to the value
-contained in the left-hand Future or Apply. If one of the Futures rejects the
-resulting Future will also be rejected. To learn more about the exact behaviour
-of `ap`, check out its [spec][FL:apply].
+Applies the function contained in the left-hand Future or Apply to the value
+contained in the right-hand Future or Apply. If one of the Futures rejects the
+resulting Future will also be rejected.
 
 ```js
-Future.of(1)
-.ap(Future.of(x => x + 1))
+Future.of(x => y => x + y)
+.ap(Future.of(1))
+.ap(Future.of(2))
 .fork(console.error, console.log);
-//> 2
+//> 3
 ```
+
+Note that even though `#ap` does *not* conform to the latest [spec][FL:apply],
+the hidden `fantasy-land/ap`-method *does*. Therefore Future remains fully
+compliant to Fantasy Land.
 
 #### swap
 ##### `#swap :: Future a b ~> Future b a`
@@ -958,9 +960,6 @@ Credits for the logo go to [Erik Fuente][8].
 [wiki:promises]:        https://github.com/fluture-js/Fluture/wiki/Comparison-to-Promises
 
 [FL]:                   https://github.com/fantasyland/fantasy-land
-[FL1]:                  https://github.com/fantasyland/fantasy-land/tree/v1.0.1
-[FL2]:                  https://github.com/fantasyland/fantasy-land/tree/v2.2.0
-[FL3]:                  https://github.com/fantasyland/fantasy-land
 [FL:alternative]:       https://github.com/fantasyland/fantasy-land#alternative
 [FL:functor]:           https://github.com/fantasyland/fantasy-land#functor
 [FL:chain]:             https://github.com/fantasyland/fantasy-land#chain

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "lodash.curry": "^4.1.1",
     "markdown-toc": "^1.0.2",
     "mocha": "^3.0.2",
+    "ramda": "^0.23.0",
     "ramda-fantasy": "^0.7.0",
     "remark-cli": "^2.1.0",
     "remark-validate-links": "^5.0.0",

--- a/src/core.js
+++ b/src/core.js
@@ -24,7 +24,7 @@ export function isFuture(x){
 }
 
 Future.prototype[FL.ap] = function Future$FL$ap(other){
-  return this._ap(other);
+  return other._ap(this);
 };
 
 Future.prototype[FL.map] = function Future$FL$map(mapper){
@@ -415,7 +415,7 @@ const check$ap = f => isFunction(f) ? f : typeError(
 );
 export class ApAction extends Action{
   constructor(other){ super(); this.other = other }
-  resolved(x){ return this.other._map(f => check$ap(f)(x)) }
+  resolved(f){ check$ap(f); return this.other._map(x => f(x)) }
   toString(){ return `ap(${this.other.toString()})` }
 }
 export class MapAction extends Action{

--- a/test/2.sequence.test.js
+++ b/test/2.sequence.test.js
@@ -10,7 +10,7 @@ describe('Sequence', () => {
 
   describe('ap', () => {
 
-    const seq = dummy.ap(of(bang));
+    const seq = of(bang).ap(dummy);
 
     describe('#fork()', () => {
 
@@ -23,7 +23,7 @@ describe('Sequence', () => {
     describe('#toString()', () => {
 
       it('returns code to create the same data-structure', () => {
-        expect(seq.toString()).to.equal('Future.of("resolved").ap(Future.of(s => `${s}!`))');
+        expect(seq.toString()).to.equal('Future.of(s => `${s}!`).ap(Future.of("resolved"))');
       });
 
     });

--- a/test/5.ap.test.js
+++ b/test/5.ap.test.js
@@ -3,6 +3,7 @@ import {Future, ap, of, reject, after} from '../index.es.js';
 import * as U from './util';
 import * as F from './futures';
 import type from 'sanctuary-type-identifiers';
+import R from 'ramda';
 
 const testInstance = ap => {
 
@@ -24,7 +25,7 @@ const testInstance = ap => {
     });
 
     it('rejects if one of the two reject', () => {
-      const left = ap(reject('err'), of(1));
+      const left = ap(reject('err'), of(U.add(1)));
       const right = ap(of(U.add(1)), reject('err'));
       return Promise.all([
         U.assertRejected(left, 'err'),
@@ -51,7 +52,7 @@ const testInstance = ap => {
 
     it('cancels the left Future if cancel is called while it is running', done => {
       const left = Future(() => () => done());
-      const right = after(20, U.add(1));
+      const right = of(U.add(1));
       const cancel = ap(left, right).fork(U.noop, U.noop);
       cancel();
     });
@@ -102,6 +103,12 @@ describe('Future#ap()', () => {
     fs.forEach(f => expect(f).to.throw(TypeError, /Future/));
   });
 
-  testInstance((a, b) => a.ap(b));
+  testInstance((a, b) => b.ap(a));
+
+});
+
+describe('Ramda#ap()', () => {
+
+  testInstance((a, b) => R.ap(b, a));
 
 });


### PR DESCRIPTION
Flipping the fluent `ap` method has some benefits, as described in #87. These should also be apparent from the changes to the README. I would like to get as many eyes as possible on this because I consider it quite a radical change.