### PR TITLE
Fix Static Land compliance of the TypeRep exposed by Flutures module version

### DIFF
--- a/index.es.js
+++ b/index.es.js
@@ -1,12 +1,5 @@
-export {
-  Future,
-  Future as default,
-  isFuture,
-  reject,
-  of,
-  never,
-  isNever
-} from './src/core';
+export {default, default as Future} from './src/future';
+export {isFuture, reject, of, never, isNever} from './src/core';
 
 export * from './src/dispatchers';
 

--- a/src/chain-rec.js
+++ b/src/chain-rec.js
@@ -1,8 +1,7 @@
-import {Future, Core} from './core';
+import {Core} from './core';
 import {Next, Done} from './internal/iteration';
 import {Undetermined, Synchronous, Asynchronous} from './internal/timing';
 import {show, showf, noop} from './internal/fn';
-import {FL} from './internal/const';
 
 export function ChainRec(step, init){
   this._step = step;
@@ -47,5 +46,3 @@ ChainRec.prototype.toString = function ChainRec$toString(){
 export function chainRec(step, init){
   return new ChainRec(step, init);
 }
-
-Future[FL.chainRec] = chainRec;

--- a/src/core.js
+++ b/src/core.js
@@ -5,7 +5,7 @@ import Denque from 'denque';
 import {show, showf, noop, moop} from './internal/fn';
 import {isFunction} from './internal/is';
 import {error, typeError, invalidArgument, invalidContext, invalidFuture} from './internal/throw';
-import {FL, $$type} from './internal/const';
+import {$$type} from './internal/const';
 import type from 'sanctuary-type-identifiers';
 
 const throwRejection = x => error(
@@ -20,22 +20,6 @@ export function Future(computation){
 export function isFuture(x){
   return x instanceof Future || type(x) === $$type;
 }
-
-Future.prototype[FL.ap] = function Future$FL$ap(other){
-  return other._ap(this);
-};
-
-Future.prototype[FL.map] = function Future$FL$map(mapper){
-  return this._map(mapper);
-};
-
-Future.prototype[FL.bimap] = function Future$FL$bimap(lmapper, rmapper){
-  return this._bimap(lmapper, rmapper);
-};
-
-Future.prototype[FL.chain] = function Future$FL$chain(mapper){
-  return this._chain(mapper);
-};
 
 Future.prototype.ap = function Future$ap(other){
   if(!isFuture(this)) invalidContext('Future#ap', this);
@@ -641,6 +625,3 @@ Sequence.prototype._fork = function Sequence$_fork(rej, res){
 Sequence.prototype.toString = function Sequence$toString(){
   return `${this._spawn.toString()}${this._actions.map(x => `.${x.toString()}`).join('')}`;
 };
-
-Future['@@type'] = $$type;
-Future[FL.of] = of;

--- a/src/future.js
+++ b/src/future.js
@@ -1,24 +1,29 @@
 import {Future, of, reject} from './core';
 import {FL, $$type} from './internal/const';
 import {chainRec} from './chain-rec';
+import {ap, map, bimap, chain} from './dispatchers';
 
 Future['@@type'] = $$type;
 Future[FL.of] = Future.of = of;
-Future[FL.chainRec] = chainRec;
+Future[FL.chainRec] = Future.chainRec = chainRec;
 Future.reject = reject;
 
+Future.ap = ap;
 Future.prototype[FL.ap] = function Future$FL$ap(other){
   return other._ap(this);
 };
 
+Future.map = map;
 Future.prototype[FL.map] = function Future$FL$map(mapper){
   return this._map(mapper);
 };
 
+Future.bimap = bimap;
 Future.prototype[FL.bimap] = function Future$FL$bimap(lmapper, rmapper){
   return this._bimap(lmapper, rmapper);
 };
 
+Future.chain = chain;
 Future.prototype[FL.chain] = function Future$FL$chain(mapper){
   return this._chain(mapper);
 };

--- a/src/future.js
+++ b/src/future.js
@@ -1,0 +1,26 @@
+import {Future, of, reject} from './core';
+import {FL, $$type} from './internal/const';
+import {chainRec} from './chain-rec';
+
+Future['@@type'] = $$type;
+Future[FL.of] = Future.of = of;
+Future[FL.chainRec] = chainRec;
+Future.reject = reject;
+
+Future.prototype[FL.ap] = function Future$FL$ap(other){
+  return other._ap(this);
+};
+
+Future.prototype[FL.map] = function Future$FL$map(mapper){
+  return this._map(mapper);
+};
+
+Future.prototype[FL.bimap] = function Future$FL$bimap(lmapper, rmapper){
+  return this._bimap(lmapper, rmapper);
+};
+
+Future.prototype[FL.chain] = function Future$FL$chain(mapper){
+  return this._chain(mapper);
+};
+
+export default Future;

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,5 @@
-import {
-  Future,
-  isFuture,
-  isNever,
-  never,
-  of,
-  reject
-} from './core';
+import Future from './future';
+import {isFuture, isNever, never, of, reject} from './core';
 
 import * as dispatchers from './dispatchers';
 

--- a/test/7.compliance.test.js
+++ b/test/7.compliance.test.js
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 import FL from 'fantasy-land';
-import {Future, reject, ap, map, bimap, chain, chainRec} from '../index.es.js';
+import Future from '../index.es.js';
 import * as U from './util';
 import jsc from 'jsverify';
 
@@ -11,8 +11,7 @@ describe('Compliance', function(){
 
   const test = (name, f) => jsc.property(name, 'number | nat', o => f(o.value));
   const eq = U.assertEqual;
-  const of = Future[FL.of];
-  const undetermined = x => Math.random() > 0.5 ? of(x) : reject(x);
+  const undetermined = x => Math.random() > 0.5 ? Future.of(x) : Future.reject(x);
 
   const I = x => x;
   const T = x => f => f(x);
@@ -22,6 +21,8 @@ describe('Compliance', function(){
   const mul3 = x => x * 3;
 
   describe('to Fantasy-Land:', () => {
+
+    const of = Future[FL.of];
 
     describe('Functor', () => {
       test('identity', x => {
@@ -118,6 +119,8 @@ describe('Compliance', function(){
   });
 
   describe('to Static-Land:', () => {
+
+    const {of, ap, map, bimap, chain, chainRec} = Future;
 
     describe('Functor', () => {
       test('identity', x => eq(


### PR DESCRIPTION
Other than improving the code organization, this ensures that `Future.of` and `Future.reject` are present in module builds as well as UMD builds.

As a result, the following will become possible:

```diff
- import {of} from 'fluture'
- of(1)
+ import Future from 'fluture'
+ Future.of(1)
```

I find that many users expect this to work.