### PR TITLE
Add Node 8 to travis test environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: node_js
 node_js:
   - "7.0.0"
   - "7"
+  - "8"
 after_success: npm run test:coverage


### PR DESCRIPTION
This PR mostly serves to fix CI errors, if they occur.