### PR TITLE
Prevent Future.parallel from cancelling settled computations

### DIFF
--- a/test/5.parallel.test.js
+++ b/test/5.parallel.test.js
@@ -127,6 +127,24 @@ describe('Parallel', () => {
       }, 30);
     });
 
+    it('[GH #123] does not cancel settled computations', done => {
+      const m1 = Object.create(F.mock);
+      const m2 = Object.create(F.mock);
+
+      m1._fork = (rej, res) => {
+        setTimeout(res, 10, 1);
+        return () => done(U.error);
+      };
+
+      m2._fork = rej => {
+        setTimeout(rej, 20, 2);
+        return () => done(U.error);
+      };
+
+      parallel(2, [m1, m2]).fork(U.noop, U.noop);
+      setTimeout(done, 50, null);
+    });
+
     it('does not resolve after being cancelled', done => {
       const cancel = parallel(1, [F.resolvedSlow, F.resolvedSlow])
       .fork(U.failRej, U.failRes);


### PR DESCRIPTION
This was a terribly difficult bug to track down. You may be interested to see this @stevenyap:

* `Future.parallel` sends a cancel signal to futures that reject
* Some `_fork` methods cannot deal with that. In particular: `Future.hook` does not expect to be cancelled right after being rejected, and this lead to an unwanted resolution signal being sent.
* The resolution signal would cause problems in the sequence interpreter. In particular: The interpreter would already be "done" and cleaned up its state when receiving the unexpected resolution signal. This in turn would cause it to try and re-resolve the current action, which finally left us with `action.resolve` throwing an error.

Fixes #123 
