### PR TITLE
Improve the performance of composing computations

### DIFF
--- a/src/internal/const.js
+++ b/src/internal/const.js
@@ -11,6 +11,6 @@ export const ordinal = ['first', 'second', 'third', 'fourth', 'fifth'];
 
 export const namespace = 'fluture';
 export const name = 'Future';
-export const version = 2;
+export const version = 3;
 
 export const $$type = `${namespace}/${name}@${version}`;

--- a/src/internal/interpreter.js
+++ b/src/internal/interpreter.js
@@ -7,11 +7,11 @@ export default function interpreter(rej, res){
 
   //This is the primary queue of actions. All actions in here will be "cold",
   //meaning they haven't had the chance yet to run concurrent computations.
-  const cold = new Denque(this._actions);
+  const cold = new Denque(this._actions.size);
 
   //This is the secondary queue of actions. All actions in here will be "hot",
   //meaning they have already had a chance to run a concurrent computation.
-  const queue = new Denque(this._actions.length);
+  const queue = new Denque(this._actions.size);
 
   //These combined variables define our current state.
   // future  = the future we are currently forking
@@ -19,7 +19,7 @@ export default function interpreter(rej, res){
   // cancel  = the cancel function of the current future
   // settled = a boolean indicating whether a new tick should start
   // async   = a boolean indicating whether we are awaiting a result asynchronously
-  let future = this._spawn, action, cancel = noop, settled, async, it;
+  let future, action, cancel = noop, settled, async = true, it;
 
   //This function is called with a future to use in the next tick.
   //Here we "flatten" the actions of another Sequence into our own actions,
@@ -31,7 +31,13 @@ export default function interpreter(rej, res){
     future = m;
 
     if(future._spawn){
-      for(let i = future._actions.length - 1; i >= 0; i--) cold.unshift(future._actions[i]);
+      let tail = future._actions;
+
+      while(!tail.isEmpty){
+        cold.unshift(tail.head);
+        tail = tail.tail;
+      }
+
       future = future._spawn;
     }
 
@@ -120,7 +126,7 @@ export default function interpreter(rej, res){
   }
 
   //Start the execution loop.
-  drain();
+  settle(this);
 
   //Return a cancellation function. It will cancel the current Future, the
   //current action, and all queued hot actions.

--- a/src/internal/list.js
+++ b/src/internal/list.js
@@ -1,0 +1,2 @@
+export const empty = ({isEmpty: true, size: 0, head: null, tail: null});
+export const cons = (head, tail) => ({isEmpty: false, size: tail.size + 1, head, tail});

--- a/test/2.sequence.test.js
+++ b/test/2.sequence.test.js
@@ -236,7 +236,7 @@ describe('Sequence', () => {
   describe('swap', () => {
 
     const seq = dummy.swap();
-    const nseq = new Sequence(rejected, []).swap();
+    const nseq = new Sequence(rejected).swap();
 
     describe('#fork()', () => {
 
@@ -294,7 +294,7 @@ describe('Sequence', () => {
 
       it('runs the other if the left rejects', done => {
         const other = Future(() => {done()});
-        const m = new Sequence(rejected, []).finally(other);
+        const m = new Sequence(rejected).finally(other);
         m.fork(noop, noop);
       });
 


### PR DESCRIPTION
Instead of using an array, and forcing it to be "immutable" by using `.concat([item])`, I've defined a very simple immutable linked list and use that to build up the list of operations to perform during interpretation.

As an example, I took the [*stack safety* example](https://github.com/fluture-js/Fluture#stack-safety) from Fluture's own README:

```js
//test.js
const Future = require('.');

const add1 = x => x + 1;
let m = Future.of(1);

for(let i = 0; i < 100000; i++){
  m = m.map(add1);
}

m.fork(console.error, console.log);
```

**Before**

```sh
$ time node test.js 
100001

real    0m30.145s
user    0m23.878s
sys     0m8.083s
```

**After**

```sh
$ time node test.js 
100001

real    0m0.153s
user    0m0.148s
sys     0m0.019s
```

For this type of script, the performance improves significantly. In practice, this improvement will probably be encountered in scripts using this pattern I've seen here and there:

```js
reduce((m, x) => m.chain(acc => reducer(acc, x)), Future.of(initial), xs)
```

The general performance as measured by the Doxbee testing suite has improved by about 11%.