### PR TITLE
Use duck-typing over other types of typing

### DIFF
--- a/src/after.js
+++ b/src/after.js
@@ -8,7 +8,7 @@ function After$race(other){
        ? other
        : isNever(other)
        ? this
-       : (other instanceof After || other instanceof RejectAfter)
+       : typeof other._time === 'number'
        ? other._time < this._time ? other : this
        : Core._race.call(this, other);
 }

--- a/src/core.js
+++ b/src/core.js
@@ -329,7 +329,9 @@ Resolved.prototype.toString = function Resolved$toString(){
 
 export const of = x => new Resolved(x);
 
-function Never(){}
+function Never(){
+  this._isNever = true;
+}
 
 Never.prototype = Object.create(Future.prototype);
 
@@ -358,7 +360,7 @@ Never.prototype.toString = function Never$toString(){
 };
 
 export const never = new Never();
-export const isNever = x => x === never;
+export const isNever = x => isFuture(x) && x._isNever === true;
 
 function Eager(future){
   this.rej = noop;


### PR DESCRIPTION
This will allow Futures of incompatible versions, Futures spawned in other runtime-context (`vm.run*`), or even ["custom made" Futures](https://gitter.im/fluture-js/Fluture?at=596d0bd8f5b3458e30571d21) to be consumed by this function.