### PR TITLE
Properly integrate ConcurrentFuture

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -126,9 +126,17 @@ declare module 'fluture' {
   export function and<L, R>(left: Future<L, any>, right: Future<L, R>): Future<L, R>
   export function and<L, R>(left: Future<L, any>): (right: Future<L, R>) => Future<L, R>
 
+  /** Race two ConcurrentFutures. See https://github.com/fluture-js/Fluture#alt */
+  export function alt<L, R>(left: ConcurrentFuture<L, R>, right: ConcurrentFuture<L, R>): ConcurrentFuture<L, R>
+  export function alt<L, R>(left: ConcurrentFuture<L, R>): (right: ConcurrentFuture<L, R>) => ConcurrentFuture<L, R>
+
   /** Apply the function in the left Future to the value in the right Future. See https://github.com/fluture-js/Fluture#ap */
   export function ap<L, RA, RB>(apply: Future<L, (value: RA) => RB>, value: Future<L, RA>): Future<L, RB>
   export function ap<L, RA, RB>(apply: Future<L, (value: RA) => RB>): (value: Future<L, RA>) => Future<L, RB>
+
+  /** Apply the function in the left ConcurrentFuture to the value in the right ConcurrentFuture. See https://github.com/fluture-js/Fluture#ap */
+  export function ap<L, RA, RB>(apply: ConcurrentFuture<L, (value: RA) => RB>, value: ConcurrentFuture<L, RA>): ConcurrentFuture<L, RB>
+  export function ap<L, RA, RB>(apply: ConcurrentFuture<L, (value: RA) => RB>): (value: ConcurrentFuture<L, RA>) => ConcurrentFuture<L, RB>
 
   /** Create a Future which resolves with the return value of the given function, or rejects with the error it throws. See https://github.com/fluture-js/Fluture#try */
   export function attempt<L, R>(fn: () => R): Future<L, R>
@@ -241,6 +249,10 @@ declare module 'fluture' {
   export function map<L, RA, RB>(mapper: (value: RA) => RB, source: Future<L, RA>): Future<L, RB>
   export function map<L, RA, RB>(mapper: (value: RA) => RB): (source: Future<L, RA>) => Future<L, RB>
 
+  /** Map over the resolution value of the given ConcurrentFuture. See https://github.com/fluture-js/Fluture#map */
+  export function map<L, RA, RB>(mapper: (value: RA) => RB, source: ConcurrentFuture<L, RA>): ConcurrentFuture<L, RB>
+  export function map<L, RA, RB>(mapper: (value: RA) => RB): (source: ConcurrentFuture<L, RA>) => ConcurrentFuture<L, RB>
+
   /** Map over the rejection reason of the given Future. See https://github.com/fluture-js/Fluture#maprej */
   export function mapRej<LA, LB, R>(mapper: (reason: LA) => LB, source: Future<LA, R>): Future<LB, R>
   export function mapRej<LA, LB, R>(mapper: (reason: LA) => LB): (source: Future<LA, R>) => Future<LB, R>
@@ -320,7 +332,22 @@ declare module 'fluture' {
   export const Future: Fluture
   export default Fluture
 
-  /** Create a ConcurrentFuture using a Future. See https://github.com/fluture-js/Fluture#concurrentfuture */
-  export function Par<L, R>(source: Future<L, R>): ConcurrentFuture<L, R>
+  export interface Par {
+
+    /** Create a ConcurrentFuture using a Future. See https://github.com/fluture-js/Fluture#concurrentfuture */
+    <L, R>(source: Future<L, R>): ConcurrentFuture<L, R>
+
+    of<R>(value: R): ConcurrentFuture<never, R>
+    zero(): ConcurrentFuture<never, never>
+
+    ap: typeof ap
+    map: typeof map
+    alt: typeof alt
+
+    '@@type': string
+
+  }
+
+  export const Par: Par
 
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,47 +1,47 @@
 declare module 'fluture' {
 
-  interface RejectFunction<L> {
+  export interface RejectFunction<L> {
     (error: L): void
   }
 
-  interface ResolveFunction<R> {
+  export interface ResolveFunction<R> {
     (value: R): void
   }
 
-  interface Cancel {
+  export interface Cancel {
     (): void
   }
 
-  interface Nodeback<E, R> {
+  export interface Nodeback<E, R> {
     (err: E | null, value?: R): void
   }
 
-  interface Next<T> {
+  export interface Next<T> {
     done: false
     value: T
   }
 
-  interface Done<T> {
+  export interface Done<T> {
     done: true
     value: T
   }
 
-  interface Iterator<N, D> {
+  export interface Iterator<N, D> {
     next(value?: N): Next<N> | Done<D>
   }
 
-  interface Generator<Y, R> {
+  export interface Generator<Y, R> {
     (): Iterator<Y, R>
   }
 
   /** The function is waiting for two more arguments. */
-  interface AwaitingTwo<A, B, R> {
+  export interface AwaitingTwo<A, B, R> {
     (a: A, b: B): R
     (a: A): (b: B) => R
   }
 
   /** The function is waiting for three more arguments. */
-  interface AwaitingThree<A, B, C, R> {
+  export interface AwaitingThree<A, B, C, R> {
     (a: A, b: B, c: C): R
     (a: A, b: B): (c: C) => R
     (a: A): AwaitingTwo<B, C, R>

--- a/src/dispatchers.js
+++ b/src/dispatchers.js
@@ -1,4 +1,5 @@
 export {ap} from './dispatchers/ap';
+export {alt} from './dispatchers/alt';
 export {map} from './dispatchers/map';
 export {bimap} from './dispatchers/bimap';
 export {chain} from './dispatchers/chain';

--- a/src/dispatchers/alt.js
+++ b/src/dispatchers/alt.js
@@ -1,0 +1,14 @@
+import Z from 'sanctuary-type-classes';
+import {partial1} from '../internal/fn';
+import {invalidArgument} from '../internal/throw';
+
+function alt$left(left, right){
+  if(!Z.Alt.test(right)) invalidArgument('alt', 1, 'be an Alt', right);
+  return Z.alt(left, right);
+}
+
+export function alt(left, right){
+  if(!Z.Alt.test(left)) invalidArgument('alt', 0, 'be an Alt', left);
+  if(arguments.length === 1) return partial1(alt$left, left);
+  return alt$left(left, right);
+}

--- a/src/internal/const.js
+++ b/src/internal/const.js
@@ -4,7 +4,8 @@ export const FL = {
   chain: 'fantasy-land/chain',
   chainRec: 'fantasy-land/chainRec',
   ap: 'fantasy-land/ap',
-  of: 'fantasy-land/of'
+  of: 'fantasy-land/of',
+  zero: 'fantasy-land/zero'
 };
 
 export const ordinal = ['first', 'second', 'third', 'fourth', 'fifth'];

--- a/src/par.js
+++ b/src/par.js
@@ -1,10 +1,11 @@
 import concurrify from 'concurrify';
 import type from 'sanctuary-type-identifiers';
 import {Core, Future, never} from './core';
-import {race} from './dispatchers';
+import {race, ap, map, alt} from './dispatchers';
 import {noop, show} from './internal/fn';
 import {isFunction} from './internal/is';
 import {typeError, invalidArgument} from './internal/throw';
+import {FL} from './internal/const';
 
 function check$ap$f(f){
   if(!isFunction(f)) typeError(
@@ -55,6 +56,12 @@ ParallelAp.prototype.toString = function ParallelAp$toString(){
 export const Par = concurrify(Future, never, race, function pap(mval, mfunc){
   return new ParallelAp(mval, mfunc);
 });
+
+Par.of = Par[FL.of];
+Par.zero = Par[FL.zero];
+Par.map = map;
+Par.ap = ap;
+Par.alt = alt;
 
 export function isParallel(x){
   return x instanceof Par || type(x) === Par['@@type'];

--- a/test/6.par.test.js
+++ b/test/6.par.test.js
@@ -1,8 +1,28 @@
 import {expect} from 'chai';
-import {Future, Par, seq, of, reject, never, ap, map} from '../index.es.js';
+import {Future, Par, seq, of, reject, never, ap, map, alt} from '../index.es.js';
 import * as U from './util';
 import * as F from './futures';
 import Z from 'sanctuary-type-classes';
+
+describe('alt()', () => {
+
+  it('is a curried binary function', () => {
+    expect(alt).to.be.a('function');
+    expect(alt.length).to.equal(2);
+    expect(alt(Par.of(1))).to.be.a('function');
+  });
+
+  it('throws when not given a Function as first argument', () => {
+    const f = () => alt(1);
+    expect(f).to.throw(TypeError, /alt.*first/);
+  });
+
+  it('throws when not given a Future as second argument', () => {
+    const f = () => alt(Par.of(1), 1);
+    expect(f).to.throw(TypeError, /alt.*second/);
+  });
+
+});
 
 describe('Par()', () => {
 
@@ -118,8 +138,6 @@ describe('Par()', () => {
   });
 
   describe('#alt', () => {
-
-    const alt = Z.alt;
 
     it('rejects when the first one rejects', () => {
       const m1 = Par(Future((rej, res) => void setTimeout(res, 15, 1)));


### PR DESCRIPTION
These changes were prompted by https://github.com/gcanti/fp-ts-fluture/pull/1.

* I included the "expose all interfaces" commit in this PR as well, since it was prompted by the same problem.
* Add "alt" function
* Add documentation for each of the associated functions
* Add overloadings for ConcurrentFuture to map and ap typings
* Add a Static Land mapping to the ConcurrentFuture representative (Par)