### PR TITLE
Optimize performance of encaseP

### DIFF
--- a/bench/encase-p.js
+++ b/bench/encase-p.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const benchmark = require('benchmark');
+const suite = new benchmark.Suite();
+const Future = require('..');
+
+const resolve = x => Promise.resolve(x);
+const noop = () => {};
+
+suite.add('encaseP', {
+  defer: true,
+  fn: (deferred) => {
+    Future.encaseP(resolve, 1).value(x => deferred.resolve(x));
+  }
+});
+
+suite.add('encaseP2', {
+  defer: true,
+  fn: (deferred) => {
+    Future.encaseP2(resolve, 1, 2).value(x => deferred.resolve(x));
+  }
+});
+
+suite.add('encaseP3', {
+  defer: true,
+  fn: (deferred) => {
+    Future.encaseP3(resolve, 1, 2, 3).value(x => deferred.resolve(x));
+  }
+});
+
+suite.on('complete', require('./_print'));
+suite.run({async: true});

--- a/src/encase-p.js
+++ b/src/encase-p.js
@@ -1,5 +1,5 @@
 import {Core} from './core';
-import {noop, show, showf, escapeTick, partial1} from './internal/fn';
+import {noop, show, showf, immediately, partial1} from './internal/fn';
 import {isThenable, isFunction} from './internal/is';
 import {invalidArgument, typeError} from './internal/throw';
 
@@ -20,7 +20,7 @@ EncaseP.prototype = Object.create(Core);
 
 EncaseP.prototype._fork = function EncaseP$fork(rej, res){
   const {_fn, _a} = this;
-  check$promise(_fn(_a), _fn, _a).then(escapeTick(res), escapeTick(rej));
+  check$promise(_fn(_a), _fn, _a).then(immediately(res), immediately(rej));
   return noop;
 };
 

--- a/src/encase-p2.js
+++ b/src/encase-p2.js
@@ -1,5 +1,5 @@
 import {Core} from './core';
-import {noop, show, showf, escapeTick, partial1, partial2} from './internal/fn';
+import {noop, show, showf, immediately, partial1, partial2} from './internal/fn';
 import {isThenable, isFunction} from './internal/is';
 import {invalidArgument, typeError} from './internal/throw';
 
@@ -22,7 +22,7 @@ EncaseP2.prototype = Object.create(Core);
 
 EncaseP2.prototype._fork = function EncaseP2$fork(rej, res){
   const {_fn, _a, _b} = this;
-  check$promise(_fn(_a, _b), _fn, _a, _b).then(escapeTick(res), escapeTick(rej));
+  check$promise(_fn(_a, _b), _fn, _a, _b).then(immediately(res), immediately(rej));
   return noop;
 };
 

--- a/src/encase-p3.js
+++ b/src/encase-p3.js
@@ -1,5 +1,5 @@
 import {Core} from './core';
-import {noop, show, showf, escapeTick, partial1, partial2, partial3} from './internal/fn';
+import {noop, show, showf, immediately, partial1, partial2, partial3} from './internal/fn';
 import {isThenable, isFunction} from './internal/is';
 import {invalidArgument, typeError} from './internal/throw';
 
@@ -24,7 +24,7 @@ EncaseP3.prototype = Object.create(Core);
 
 EncaseP3.prototype._fork = function EncaseP3$fork(rej, res){
   const {_fn, _a, _b, _c} = this;
-  check$promise(_fn(_a, _b, _c), _fn, _a, _b, _c).then(escapeTick(res), escapeTick(rej));
+  check$promise(_fn(_a, _b, _c), _fn, _a, _b, _c).then(immediately(res), immediately(rej));
   return noop;
 };
 

--- a/src/internal/bc.js
+++ b/src/internal/bc.js
@@ -1,0 +1,1 @@
+export const setImmediate = (f, x) => setTimeout(f, 0, x);

--- a/src/internal/fn.js
+++ b/src/internal/fn.js
@@ -1,5 +1,10 @@
 import Z from 'sanctuary-type-classes';
 import inspectf from 'inspect-f';
+import * as bc from './bc';
+
+const setImmediate = typeof global.setImmediate === 'function'
+  ? global.setImmediate
+  : /* istanbul ignore next: environment-specific */ bc.setImmediate;
 
 export const noop = function noop(){};
 export const moop = function moop(){ return this };
@@ -29,6 +34,4 @@ export const partial3 = (f, a, b, c) => function bound3(d){
   return f(a, b, c, d);
 };
 
-export const escapeTick = f => function imprisoned(x){
-  setTimeout(function escaped(){ f(x) }, 0);
-};
+export const immediately = f => x => setImmediate(f, x);

--- a/src/try-p.js
+++ b/src/try-p.js
@@ -1,5 +1,5 @@
 import {Core} from './core';
-import {noop, show, showf, escapeTick} from './internal/fn';
+import {noop, show, showf, immediately} from './internal/fn';
 import {isThenable, isFunction} from './internal/is';
 import {invalidArgument, typeError} from './internal/throw';
 
@@ -18,7 +18,7 @@ TryP.prototype = Object.create(Core);
 
 TryP.prototype._fork = function TryP$fork(rej, res){
   const {_fn} = this;
-  check$promise(_fn(), _fn).then(escapeTick(res), escapeTick(rej));
+  check$promise(_fn(), _fn).then(immediately(res), immediately(rej));
   return noop;
 };
 

--- a/test/0.bc.test.js
+++ b/test/0.bc.test.js
@@ -1,0 +1,23 @@
+import {expect} from 'chai';
+import * as bc from '../src/internal/bc';
+
+describe('bc', () => {
+
+  describe('.setImmediate()', () => {
+
+    it('calls the given function with the given argument', done => {
+      bc.setImmediate(done, null);
+    });
+
+    it('schedules the function call relatively quickly', done => {
+      let message = '';
+      bc.setImmediate(x => { message = x }, 'hello');
+      setTimeout(() => {
+        expect(message).to.equal('hello');
+        done();
+      });
+    });
+
+  });
+
+});


### PR DESCRIPTION
**Before**

```text
$ node bench/encase-p.js 
encaseP x 766 ops/sec ±0.68% (57 runs sampled)
encaseP2 x 778 ops/sec ±0.89% (79 runs sampled)
encaseP3 x 775 ops/sec ±0.71% (79 runs sampled)
```

(with an average CPU load of about 2%)

**After**

```text
$ node bench/encase-p.js 
encaseP x 398,000 ops/sec ±0.44% (83 runs sampled)
encaseP2 x 357,165 ops/sec ±4.89% (76 runs sampled)
encaseP3 x 364,562 ops/sec ±1.56% (82 runs sampled)
```

(with an average CPU load of about 80%)

---

Resolves #148 