### PR TITLE
Fix cancellation of Futures created by encaseP

### DIFF
--- a/src/encase-p.js
+++ b/src/encase-p.js
@@ -1,5 +1,5 @@
 import {Core} from './core';
-import {noop, show, showf, immediately, partial1} from './internal/fn';
+import {show, showf, immediately, partial1} from './internal/fn';
 import {isThenable, isFunction} from './internal/is';
 import {invalidArgument, typeError} from './internal/throw';
 
@@ -20,8 +20,19 @@ EncaseP.prototype = Object.create(Core);
 
 EncaseP.prototype._fork = function EncaseP$fork(rej, res){
   const {_fn, _a} = this;
-  check$promise(_fn(_a), _fn, _a).then(immediately(res), immediately(rej));
-  return noop;
+  let open = true;
+  check$promise(_fn(_a), _fn, _a).then(immediately(function EncaseP$res(x){
+    if(open){
+      open = false;
+      res(x);
+    }
+  }), immediately(function EncaseP$rej(x){
+    if(open){
+      open = false;
+      rej(x);
+    }
+  }));
+  return function EncaseP$cancel(){ open = false };
 };
 
 EncaseP.prototype.toString = function EncaseP$toString(){

--- a/src/encase-p2.js
+++ b/src/encase-p2.js
@@ -1,5 +1,5 @@
 import {Core} from './core';
-import {noop, show, showf, immediately, partial1, partial2} from './internal/fn';
+import {show, showf, immediately, partial1, partial2} from './internal/fn';
 import {isThenable, isFunction} from './internal/is';
 import {invalidArgument, typeError} from './internal/throw';
 
@@ -22,8 +22,19 @@ EncaseP2.prototype = Object.create(Core);
 
 EncaseP2.prototype._fork = function EncaseP2$fork(rej, res){
   const {_fn, _a, _b} = this;
-  check$promise(_fn(_a, _b), _fn, _a, _b).then(immediately(res), immediately(rej));
-  return noop;
+  let open = true;
+  check$promise(_fn(_a, _b), _fn, _a, _b).then(immediately(function EncaseP2$res(x){
+    if(open){
+      open = false;
+      res(x);
+    }
+  }), immediately(function EncaseP2$rej(x){
+    if(open){
+      open = false;
+      rej(x);
+    }
+  }));
+  return function EncaseP2$cancel(){ open = false };
 };
 
 EncaseP2.prototype.toString = function EncaseP2$toString(){

--- a/src/encase-p3.js
+++ b/src/encase-p3.js
@@ -1,5 +1,5 @@
 import {Core} from './core';
-import {noop, show, showf, immediately, partial1, partial2, partial3} from './internal/fn';
+import {show, showf, immediately, partial1, partial2, partial3} from './internal/fn';
 import {isThenable, isFunction} from './internal/is';
 import {invalidArgument, typeError} from './internal/throw';
 
@@ -24,8 +24,19 @@ EncaseP3.prototype = Object.create(Core);
 
 EncaseP3.prototype._fork = function EncaseP3$fork(rej, res){
   const {_fn, _a, _b, _c} = this;
-  check$promise(_fn(_a, _b, _c), _fn, _a, _b, _c).then(immediately(res), immediately(rej));
-  return noop;
+  let open = true;
+  check$promise(_fn(_a, _b, _c), _fn, _a, _b, _c).then(immediately(function EncaseP3$res(x){
+    if(open){
+      open = false;
+      res(x);
+    }
+  }), immediately(function EncaseP3$rej(x){
+    if(open){
+      open = false;
+      rej(x);
+    }
+  }));
+  return function EncaseP3$cancel(){ open = false };
 };
 
 EncaseP3.prototype.toString = function EncaseP3$toString(){

--- a/src/try-p.js
+++ b/src/try-p.js
@@ -1,5 +1,5 @@
 import {Core} from './core';
-import {noop, show, showf, immediately} from './internal/fn';
+import {show, showf, immediately} from './internal/fn';
 import {isThenable, isFunction} from './internal/is';
 import {invalidArgument, typeError} from './internal/throw';
 
@@ -18,8 +18,19 @@ TryP.prototype = Object.create(Core);
 
 TryP.prototype._fork = function TryP$fork(rej, res){
   const {_fn} = this;
-  check$promise(_fn(), _fn).then(immediately(res), immediately(rej));
-  return noop;
+  let open = true;
+  check$promise(_fn(), _fn).then(immediately(function TryP$res(x){
+    if(open){
+      open = false;
+      res(x);
+    }
+  }), immediately(function TryP$rej(x){
+    if(open){
+      open = false;
+      rej(x);
+    }
+  }));
+  return function TryP$cancel(){ open = false };
 };
 
 TryP.prototype.toString = function TryP$toString(){

--- a/test/5.encase-p.test.js
+++ b/test/5.encase-p.test.js
@@ -1,3 +1,5 @@
+/* eslint prefer-promise-reject-errors: 0 */
+
 import {expect} from 'chai';
 import {Future, encaseP, encaseP2, encaseP3, tryP} from '../index.es.js';
 import * as U from './util';
@@ -119,6 +121,18 @@ describe('EncaseP', () => {
         return U.assertRejected(actual, U.error);
       });
 
+      it('ensures no resolution happens after cancel', done => {
+        const actual = tryP(_ => Promise.resolve(1));
+        actual.fork(U.failRej, U.failRes)();
+        setTimeout(done, 20);
+      });
+
+      it('ensures no rejection happens after cancel', done => {
+        const actual = tryP(_ => Promise.reject(1));
+        actual.fork(U.failRej, U.failRes)();
+        setTimeout(done, 20);
+      });
+
     });
 
     describe('(unary)', () => {
@@ -136,6 +150,18 @@ describe('EncaseP', () => {
       it('rejects with rejection reason of the returned Promise', () => {
         const actual = encaseP(_ => Promise.reject(U.error), 1);
         return U.assertRejected(actual, U.error);
+      });
+
+      it('ensures no resolution happens after cancel', done => {
+        const actual = encaseP(x => Promise.resolve(x + 1), 1);
+        actual.fork(U.failRej, U.failRes)();
+        setTimeout(done, 20);
+      });
+
+      it('ensures no rejection happens after cancel', done => {
+        const actual = encaseP(x => Promise.reject(x + 1), 1);
+        actual.fork(U.failRej, U.failRes)();
+        setTimeout(done, 20);
       });
 
     });
@@ -157,6 +183,18 @@ describe('EncaseP', () => {
         return U.assertRejected(actual, U.error);
       });
 
+      it('ensures no resolution happens after cancel', done => {
+        const actual = encaseP2((x, y) => Promise.resolve(y + 1), 1, 1);
+        actual.fork(U.failRej, U.failRes)();
+        setTimeout(done, 20);
+      });
+
+      it('ensures no rejection happens after cancel', done => {
+        const actual = encaseP2((x, y) => Promise.reject(y + 1), 1, 1);
+        actual.fork(U.failRej, U.failRes)();
+        setTimeout(done, 20);
+      });
+
     });
 
     describe('(ternary)', () => {
@@ -174,6 +212,18 @@ describe('EncaseP', () => {
       it('rejects with rejection reason of the returned Promise', () => {
         const actual = encaseP3(_ => Promise.reject(U.error), 1, 1, 1);
         return U.assertRejected(actual, U.error);
+      });
+
+      it('ensures no resolution happens after cancel', done => {
+        const actual = encaseP3((x, y, z) => Promise.resolve(z + 1), 1, 1, 1);
+        actual.fork(U.failRej, U.failRes)();
+        setTimeout(done, 20);
+      });
+
+      it('ensures no rejection happens after cancel', done => {
+        const actual = encaseP3((x, y, z) => Promise.reject(z + 1), 1, 1, 1);
+        actual.fork(U.failRej, U.failRes)();
+        setTimeout(done, 20);
       });
 
     });


### PR DESCRIPTION
Even though Promises themselves are not cancellable, we should still prevent the continuations from getting the result after the derrived Future is cancelled.