### PR TITLE
WIP: Fix type of default export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -330,7 +330,7 @@ declare module 'fluture' {
   }
 
   export const Future: Fluture
-  export default Fluture
+  export default {} as Fluture
 
   export interface Par {
 


### PR DESCRIPTION
- [x] Fix the type of the default export. We were telling typescript that the default export *is* a type, where it should have been *of that* type.
- [ ] Fix incompatibilities between TypeScripts own IterableIterator interfae, and Fluture's. When using a generator function in `go()`, TypeScript detects this incompatibility. A possible fix might be to have my own (more sctrict) iterable extend from the less strict TypeScript built-in.

/cc @tetsuo