### PR TITLE
Fixes: index.d.ts(333,18): error TS2714

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -330,7 +330,7 @@ declare module 'fluture' {
   }
 
   export var Future: Fluture
-  export default {} as Fluture
+  export default Future
 
   export interface Par {
 

--- a/package.json
+++ b/package.json
@@ -21,9 +21,10 @@
     "lint": "eslint src test index.es.js README.md",
     "lint:readme": "remark --no-stdout --frail -u remark-validate-links README.md",
     "release": "npm outdated --long; xyz --edit --repo git@github.com:fluture-js/Fluture.git --tag 'X.Y.Z' --script scripts/distribute --increment",
-    "test": "npm run lint && npm run lint:readme && npm run test:unit",
+    "test": "npm run lint && npm run lint:readme && npm run test:unit && npm run test:types",
     "test:unit": "npm run build && nyc --include src mocha --require @std/esm --ui bdd --reporter list --check-leaks --full-trace test/**.test.js",
-    "test:coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov"
+    "test:coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
+    "test:types": "tsc index.d.ts"
   },
   "author": "Aldwin Vlasblom <aldwin.vlasblom@gmail.com> (https://github.com/Avaq)",
   "homepage": "https://github.com/fluture-js/Fluture",
@@ -84,6 +85,7 @@
     "rollup": "^0.50.0",
     "rollup-plugin-commonjs": "^8.2.1",
     "rollup-plugin-node-resolve": "^3.0.0",
+    "typescript": "^2.6.1",
     "xyz": "^2.0.1"
   }
 }


### PR DESCRIPTION
#164 introduced a bug at https://github.com/fluture-js/Fluture/pull/164/commits/77f102a7d3e6a666ef88447e4e209b13b1b6178e by exporting a default type that was an object.

This reverts it to how it was originally https://github.com/fluture-js/Fluture/commit/48d3a6e0b9fa0058cfea1601ead26e030412311e#diff-b52768974e6bc0faccb7d4b75b162c99R315 

Fixes this:
```
index.d.ts(333,18): error TS2714: The expression of an export assignment must be an identifier or qualified name in an ambient context.
```

This is a compilation problem I get using `fluture` as a dependency, and also adds a test to make sure that's not going to happen again..!

These should result in the same type:
```ts
import Future from 'fluture'
import {Future} from 'fluture'
```

@Avaq why was this changed?