### PR TITLE
Clarify that the rejection reason is also cached

### DIFF
--- a/README.md
+++ b/README.md
@@ -1430,9 +1430,9 @@ cache :: Future a b -> Future a b
 
 </details>
 
-Returns a Future which caches the resolution value of the given Future so that
-whenever it's forked, it can load the value from cache rather than reexecuting
-the chain.
+Returns a Future which caches the resolution value or rejection reason of the
+given Future so that whenever it's forked, it can load the value from cache
+rather than reexecuting the chain.
 
 ```js
 var {readFile} = require('fs');


### PR DESCRIPTION
Previously implied that a rejected Future would not be cached, which is untrue.