### PR TITLE
Unpin std/esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "sanctuary-type-identifiers": "^2.0.0"
   },
   "devDependencies": {
-    "@std/esm": "0.19.6",
+    "@std/esm": "0.19.x",
     "benchmark": "^2.1.0",
     "chai": "^4.1.2",
     "codecov": "^3.0.0",

--- a/test/0.bc.test.js
+++ b/test/0.bc.test.js
@@ -1,4 +1,3 @@
-import {expect} from 'chai';
 import * as bc from '../src/internal/bc';
 
 describe('bc', function(){
@@ -7,15 +6,6 @@ describe('bc', function(){
 
     it('calls the given function with the given argument', function(done){
       bc.setImmediate(done, null);
-    });
-
-    it('schedules the function call relatively quickly', function(done){
-      var message = '';
-      bc.setImmediate(function(x){ message = x }, 'hello');
-      setTimeout(function(){
-        expect(message).to.equal('hello');
-        done();
-      });
     });
 
   });


### PR DESCRIPTION
> std/esm appears to have stabalized, releasing fewer minor versions that break my build. Therefore, I think it's worth unpinning it and allowing for automatic minor updates. This should make greenkeeper less spammy.

Closes #210 
