### PR TITLE
Drop support for "primitive" dispatching

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,7 +26,9 @@
     "camelcase": 0,
     "indent": 0,
     "func-name-matching": 0,
-    "no-console": 2
+    "no-console": 2,
+    "eqeqeq": [2, "smart"],
+    "no-eq-null": 0
   },
   "overrides": [
     {

--- a/README.md
+++ b/README.md
@@ -279,20 +279,15 @@ The concrete types you will encounter throughout this documentation:
 
 #### Type classes
 
-Some signatures contain "constrained type variables". These constraints are
-expressed by means of [type classes][Guide:constraints], specifically those defined by
-[Fantasy Land][FL] and verified by [Sanctuary Type Classes][Z]:
+Some signatures contain [constrained type variables][Guide:constraints].
+Generally, these constraints express that some value must conform to a
+[Fantasy Land][FL]-specified interface.
 
-- [**Functor**][Z:Functor] - Values which conform to the
-  [Fantasy Land Functor specification][FL:functor].
-- [**Bifunctor**][Z:Bifunctor] - Values which conform to the
-  [Fantasy Land Bifunctor specification][FL:bifunctor].
-- [**Chain**][Z:Chain] - Values which conform to the
-  [Fantasy Land Chain specification][FL:chain].
-- [**Apply**][Z:Apply] - Values which conform to the
-  [Fantasy Land Apply specification][FL:apply].
-- [**Alt**][Z:Alt] - Values which conform to the
-  [Fantasy Land Alt specification][FL:alt].
+- **Functor** - [Fantasy Land Functor][FL:functor] conformant values.
+- **Bifunctor** - [Fantasy Land Bifunctor][FL:bifunctor] conformant values.
+- **Chain** - [Fantasy Land Chain][FL:chain] conformant values.
+- **Apply** - [Fantasy Land Apply][FL:apply] conformant values.
+- **Alt** - [Fantasy Land Alt][FL:alt] conformant values.
 
 ### Cancellation
 
@@ -1763,13 +1758,6 @@ it is **not** the correct way to [consume a Future](#consuming-futures).
 [SS]:                   https://github.com/sanctuary-js/sanctuary-show
 [STI]:                  https://github.com/sanctuary-js/sanctuary-type-identifiers
 [FST]:                  https://github.com/fluture-js/fluture-sanctuary-types
-
-[Z]:                    https://github.com/sanctuary-js/sanctuary-type-classes#readme
-[Z:Functor]:            https://github.com/sanctuary-js/sanctuary-type-classes#Functor
-[Z:Bifunctor]:          https://github.com/sanctuary-js/sanctuary-type-classes#Bifunctor
-[Z:Chain]:              https://github.com/sanctuary-js/sanctuary-type-classes#Chain
-[Z:Apply]:              https://github.com/sanctuary-js/sanctuary-type-classes#Apply
-[Z:Alt]:                https://github.com/sanctuary-js/sanctuary-type-classes#Alt
 
 [$]:                    https://github.com/sanctuary-js/sanctuary-def
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "concurrify": "^1.0.0",
     "denque": "^1.1.1",
     "sanctuary-show": "^1.0.0",
-    "sanctuary-type-classes": "^9.0.0",
     "sanctuary-type-identifiers": "^2.0.0"
   },
   "devDependencies": {
@@ -84,6 +83,7 @@
     "rollup-plugin-commonjs": "^9.1.6",
     "rollup-plugin-node-resolve": "^3.0.0",
     "sanctuary-benchmark": "^1.0.0",
+    "sanctuary-type-classes": "^9.0.0",
     "typescript": "^3.0.1",
     "xyz": "^3.0.0"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,6 @@ var dependencies = {
   'concurrify': 'concurrify',
   'denque': 'Denque',
   'sanctuary-show': 'sanctuaryShow',
-  'sanctuary-type-classes': 'sanctuaryTypeClasses',
   'sanctuary-type-identifiers': 'sanctuaryTypeIdentifiers'
 };
 

--- a/src/dispatchers/alt.mjs
+++ b/src/dispatchers/alt.mjs
@@ -1,14 +1,15 @@
-import Z from 'sanctuary-type-classes';
+import {isAlt} from '../internal/predicates';
+import {FL} from '../internal/const';
 import {partial1} from '../internal/utils';
 import {throwInvalidArgument} from '../internal/throw';
 
 function alt$left(left, right){
-  if(!Z.Alt.test(right)) throwInvalidArgument('alt', 1, 'be an Alt', right);
-  return Z.alt(left, right);
+  if(!isAlt(right)) throwInvalidArgument('alt', 1, 'be an Alt', right);
+  return left[FL.alt](right);
 }
 
 export function alt(left, right){
-  if(!Z.Alt.test(left)) throwInvalidArgument('alt', 0, 'be an Alt', left);
+  if(!isAlt(left)) throwInvalidArgument('alt', 0, 'be an Alt', left);
   if(arguments.length === 1) return partial1(alt$left, left);
   return alt$left(left, right);
 }

--- a/src/dispatchers/ap.mjs
+++ b/src/dispatchers/ap.mjs
@@ -1,14 +1,15 @@
-import Z from 'sanctuary-type-classes';
+import {isApply} from '../internal/predicates';
+import {FL} from '../internal/const';
 import {partial1} from '../internal/utils';
 import {throwInvalidArgument} from '../internal/throw';
 
 function ap$mval(mval, mfunc){
-  if(!Z.Apply.test(mfunc)) throwInvalidArgument('Future.ap', 1, 'be an Apply', mfunc);
-  return Z.ap(mval, mfunc);
+  if(!isApply(mfunc)) throwInvalidArgument('Future.ap', 1, 'be an Apply', mfunc);
+  return mfunc[FL.ap](mval);
 }
 
 export function ap(mval, mfunc){
-  if(!Z.Apply.test(mval)) throwInvalidArgument('Future.ap', 0, 'be an Apply', mval);
+  if(!isApply(mval)) throwInvalidArgument('Future.ap', 0, 'be an Apply', mval);
   if(arguments.length === 1) return partial1(ap$mval, mval);
   return ap$mval(mval, mfunc);
 }

--- a/src/dispatchers/bimap.mjs
+++ b/src/dispatchers/bimap.mjs
@@ -1,11 +1,12 @@
-import Z from 'sanctuary-type-classes';
+import {isBifunctor} from '../internal/predicates';
+import {FL} from '../internal/const';
 import {partial1, partial2} from '../internal/utils';
 import {isFunction} from '../internal/predicates';
 import {throwInvalidArgument} from '../internal/throw';
 
 function bimap$lmapper$rmapper(lmapper, rmapper, m){
-  if(!Z.Bifunctor.test(m)) throwInvalidArgument('Future.bimap', 2, 'be a Bifunctor', m);
-  return Z.bimap(lmapper, rmapper, m);
+  if(!isBifunctor(m)) throwInvalidArgument('Future.bimap', 2, 'be a Bifunctor', m);
+  return m[FL.bimap](lmapper, rmapper);
 }
 
 function bimap$lmapper(lmapper, rmapper, m){

--- a/src/dispatchers/chain.mjs
+++ b/src/dispatchers/chain.mjs
@@ -1,11 +1,12 @@
-import Z from 'sanctuary-type-classes';
+import {isChain} from '../internal/predicates';
+import {FL} from '../internal/const';
 import {partial1} from '../internal/utils';
 import {isFunction} from '../internal/predicates';
 import {throwInvalidArgument} from '../internal/throw';
 
 function chain$chainer(chainer, m){
-  if(!Z.Chain.test(m)) throwInvalidArgument('Future.chain', 1, 'be a Chain', m);
-  return Z.chain(chainer, m);
+  if(!isChain(m)) throwInvalidArgument('Future.chain', 1, 'be a Chain', m);
+  return m[FL.chain](chainer);
 }
 
 export function chain(chainer, m){

--- a/src/dispatchers/map.mjs
+++ b/src/dispatchers/map.mjs
@@ -1,11 +1,12 @@
-import Z from 'sanctuary-type-classes';
+import {isFunctor} from '../internal/predicates';
+import {FL} from '../internal/const';
 import {partial1} from '../internal/utils';
 import {isFunction} from '../internal/predicates';
 import {throwInvalidArgument} from '../internal/throw';
 
 function map$mapper(mapper, m){
-  if(!Z.Functor.test(m)) throwInvalidArgument('Future.map', 1, 'be a Functor', m);
-  return Z.map(mapper, m);
+  if(!isFunctor(m)) throwInvalidArgument('Future.map', 1, 'be a Functor', m);
+  return m[FL.map](mapper);
 }
 
 export function map(mapper, m){

--- a/src/internal/const.mjs
+++ b/src/internal/const.mjs
@@ -1,9 +1,10 @@
 export var FL = {
-  map: 'fantasy-land/map',
+  alt: 'fantasy-land/alt',
+  ap: 'fantasy-land/ap',
   bimap: 'fantasy-land/bimap',
   chain: 'fantasy-land/chain',
   chainRec: 'fantasy-land/chainRec',
-  ap: 'fantasy-land/ap',
+  map: 'fantasy-land/map',
   of: 'fantasy-land/of',
   zero: 'fantasy-land/zero'
 };

--- a/src/internal/predicates.mjs
+++ b/src/internal/predicates.mjs
@@ -3,7 +3,7 @@ export function isFunction(f){
 }
 
 export function isThenable(m){
-  return m instanceof Promise || Boolean(m) && isFunction(m.then);
+  return m instanceof Promise || m != null && isFunction(m.then);
 }
 
 export function isBoolean(f){

--- a/src/internal/predicates.mjs
+++ b/src/internal/predicates.mjs
@@ -1,3 +1,5 @@
+import {FL} from './const';
+
 export function isFunction(f){
   return typeof f === 'function';
 }
@@ -28,4 +30,28 @@ export function isIterator(i){
 
 export function isArray(x){
   return Array.isArray(x);
+}
+
+export function hasMethod(method, x){
+  return x != null && isFunction(x[method]);
+}
+
+export function isFunctor(x){
+  return hasMethod(FL.map, x);
+}
+
+export function isAlt(x){
+  return isFunctor(x) && hasMethod(FL.alt, x);
+}
+
+export function isApply(x){
+  return isFunctor(x) && hasMethod(FL.ap, x);
+}
+
+export function isBifunctor(x){
+  return isFunctor(x) && hasMethod(FL.bimap, x);
+}
+
+export function isChain(x){
+  return isApply(x) && hasMethod(FL.chain, x);
 }


### PR DESCRIPTION
A while ago, I added sanctuary-type-classes as a dependency to Fluture,
primarily to gain its fantastic toString implementation. As a
side-effect, Fluture got to use its dispatcher implementations for ap,
map, bimap, chain, and alt.

Now that sanctuary-show has the toString logic, there is little to gain
from including the entirety of sanctuary-type-classes for dispatching
to FL methods.

The gains were:

- Some of its logic did not have to be reimplemented. Though as shown
  by this diff, not that much.
- Fluture dispatchers could be used on primitive types
  (like Fluture.map(f, [1, 2, 3])). I believe this functionality was
  rarely, if ever, used. Furthermore, TypeScript users were unable to
  use it out of the box because of the limitations of TypeScript.

The losses however:

- A fairly big increase of the bundle size, which as of recent I have
  been working to reduce.
- A minor hit on the performance of these dispatchers.
- The management cost of an additional dependency.
- Breaking changes to sanctuary-type-classes primitive dispatching would
  propagate to a breaking change in Fluture which was confusing to users
  (see https://git.io/fAGsJ#issuecomment-355616168 for example).