### PR TITLE
Add 'resolve' as an alias to 'of'

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,13 +456,17 @@ Future(function computation(reject, resolve){
 <details><summary><code>of :: b -> Future a b</code></summary>
 
 ```hs
-of        :: b -> Future a b
-Future.of :: b -> Future a b
+of             :: b -> Future a b
+resolve        :: b -> Future a b
+Future.of      :: b -> Future a b
+Future.resolve :: b -> Future a b
 ```
 
 </details>
 
 Creates a Future which immediately resolves with the given value.
+
+This function has an alias `resolve`.
 
 ```js
 var eventualThing = Future.of('world');

--- a/index.d.ts
+++ b/index.d.ts
@@ -279,6 +279,9 @@ declare module 'fluture' {
   /** Create a Future with the given resolution value. See https://github.com/fluture-js/Fluture#of */
   export function of<L, R>(value: R): FutureInstance<L, R>
 
+  /** Create a Future with the given resolution value. See https://github.com/fluture-js/Fluture#of */
+  export function resolve<L, R>(value: R): FutureInstance<L, R>
+
   /** Logical or for Futures. See https://github.com/fluture-js/Fluture#or */
   export function or<L, R>(left: FutureInstance<L, R>, right: FutureInstance<L, R>): FutureInstance<L, R>
   export function or<L, R>(left: FutureInstance<L, R>): (right: FutureInstance<L, R>) => FutureInstance<L, R>
@@ -335,7 +338,8 @@ declare module 'fluture' {
     bimap: typeof bimap
     chain: typeof chain
     map: typeof map
-    of: typeof of
+    of: typeof resolve
+    resolve: typeof resolve
     reject: typeof reject
 
     '@@type': string

--- a/index.mjs
+++ b/index.mjs
@@ -6,7 +6,7 @@ import {FL} from './src/internal/const';
 import {chainRec} from './src/chain-rec';
 import {ap, map, bimap, chain, race, alt} from './src/dispatchers/index';
 
-Future.of = Future[FL.of] = resolve;
+Future.resolve = Future.of = Future[FL.of] = resolve;
 Future.chainRec = Future[FL.chainRec] = chainRec;
 Future.reject = reject;
 Future.ap = ap;


### PR DESCRIPTION
I find myself doing one of the following way too often:

    import {of as resolve} from 'fluture';
    const {of: resolve} = require('fluture');