### PR TITLE
Remove cancellation hook from Future.finally

### DIFF
--- a/src/future.mjs
+++ b/src/future.mjs
@@ -617,11 +617,8 @@ defineBimapperAction('fold', {
 });
 
 var finallyAction = {
-  cancel: function FinallyAction$cancel(){ this.other._interpret(noop, noop, noop)() },
   rejected: function FinallyAction$rejected(x){ return this.other._and(new Rejected(x)) },
-  resolved: function FinallyAction$resolved(x){
-    return this.other._map(function FoldAction$resolved$mapper(){ return x });
-  }
+  resolved: function FinallyAction$resolved(x){ return this.other._and(new Resolved(x)) }
 };
 
 defineOtherAction('finally', finallyAction);

--- a/test/5.finally.test.mjs
+++ b/test/5.finally.test.mjs
@@ -49,11 +49,6 @@ var testInstance = function (fin){
       setTimeout(done, 25);
     });
 
-    it('immediately runs and cancels the disposal Future when cancelled early', function (done){
-      var cancel = fin(F.resolvedSlow, Future(function (){ return function (){ return done() } }))._interpret(done, U.failRej, U.failRes);
-      setTimeout(cancel, 10);
-    });
-
   });
 
 };


### PR DESCRIPTION
A less severe alternative to #279 

---

To make Future.finally more reliable as a tool which guarantees
execution of the cleanup handler, it would run and cancel the handler
when it would itself be cancelled.

However, this behaviour is subject to some issues:

- The cleanup handler would run when a Future prior to the finally-call
  got cancelled, leading to attempts to dispose yet-to-be-acquired
  resources.
- The cleanup handler would be immediately cancelled, which meant that
  unless it was prepared for ignoring the cancellation signal, cleanup
  wouldn't even happen.

This commit fixes both of those issues by removing this behaviour
altogether. Finally then becomes a function to use solely for cases
where something should happen as a side-effect under rejection and under
resolution of a Future, as its documentation already states.