### PR TITLE
Add the Future#pipe method

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ for sponsoring the project.
 
 <details><summary>Transforming and combining Futures</summary>
 
+- [`pipe`: Apply a function to a Future in a fluent method chain](#pipe)
 - [`map`: Synchronously process the success value in a Future](#map)
 - [`bimap`: Synchronously process the success or failure value in a Future](#bimap)
 - [`chain`: Asynchronously process the success value in a Future](#chain)
@@ -208,6 +209,7 @@ for sponsoring the project.
 <details><summary>Resource management and utilities</summary>
 
 - [`hook`: Safely create and dispose resources](#hook)
+- [`pipe`: Apply a function to a Future in a fluent method chain](#pipe)
 - [`cache`: Cache a Future so that it can be forked multiple times](#cache)
 - [`isFuture`: Determine whether a value is a Fluture compatible Future](#isfuture)
 - [`never`: A Future that never settles](#never)
@@ -1604,6 +1606,30 @@ will be ignored.
 
 ### Utility functions
 
+#### pipe
+
+<details><summary><code>pipe :: Future a b ~> (Future a b -> c) -> c</code></summary>
+
+```hs
+pipe :: Future a b ~> (Future a b -> c) -> c
+```
+
+</details>
+
+A method available on all Futures to allow arbitrary functions over Futures to
+be included in a fluent-style method chain.
+
+This method is particularly useful in combination with functions derived from
+Fantasy Land implementations, for example [`S.join`][S:join]:
+
+```js
+Future.of(42)
+.map(Future.resolve)
+.pipe(S.join)
+.value(console.log);
+//> 42
+```
+
 #### cache
 
 <details><summary><code>cache :: Future a b -> Future a b</code></summary>
@@ -1758,6 +1784,7 @@ it is **not** the correct way to [consume a Future](#consuming-futures).
 [S:Either]:             https://sanctuary.js.org/#either-type
 [S:is]:                 https://sanctuary.js.org/#is
 [S:create]:             https://sanctuary.js.org/#create
+[S:join]:               https://sanctuary.js.org/#join
 
 [SS]:                   https://github.com/sanctuary-js/sanctuary-show
 [STI]:                  https://github.com/sanctuary-js/sanctuary-type-identifiers

--- a/index.d.ts
+++ b/index.d.ts
@@ -57,6 +57,9 @@ declare module 'fluture' {
 
   export interface FutureInstance<L, R> {
 
+    /** Apply a function to this Future. See https://github.com/fluture-js/Fluture#pipe */
+    pipe<T>(fn: (future: FutureInstance<L, R>) => T): T
+
     /** Logical and for Futures. See https://github.com/fluture-js/Fluture#and */
     and<RB>(right: FutureInstance<L, RB>): FutureInstance<L, RB>
 

--- a/src/future.mjs
+++ b/src/future.mjs
@@ -44,6 +44,12 @@ Future.prototype[FL.chain] = function Future$FL$chain(mapper){
   return this._chain(mapper);
 };
 
+Future.prototype.pipe = function Future$pipe(f){
+  if(!isFuture(this)) throwInvalidContext('Future#pipe', this);
+  if(!isFunction(f)) throwInvalidArgument('Future#pipe', 0, 'to be a Function', f);
+  return f(this);
+};
+
 Future.prototype.fork = function Future$fork(rej, res){
   if(!isFuture(this)) throwInvalidContext('Future#fork', this);
   if(!isFunction(rej)) throwInvalidArgument('Future#fork', 0, 'to be a Function', rej);

--- a/test/1.future.test.mjs
+++ b/test/1.future.test.mjs
@@ -284,6 +284,31 @@ describe('Future', function (){
 
   });
 
+  describe('#pipe()', function (){
+
+    it('throws when invoked out of context', function (){
+      var f = function (){ return F.mock.pipe.call(null, U.noop) };
+      expect(f).to.throw(TypeError, /Future/);
+    });
+
+    it('throws TypeError when not given a function', function (){
+      var xs = [NaN, {}, [], 1, 'a', new Date, undefined, null];
+      var fs = xs.map(function (x){ return function (){ return F.mock.pipe(x) } });
+      fs.forEach(function (f){ return expect(f).to.throw(TypeError, /Future/) });
+    });
+
+    it('calls the given function on itself', function (){
+      var guard = {};
+      var actual = F.mock.pipe(f);
+      expect(actual).to.equal(guard);
+      function f (m){
+        expect(m).to.equal(F.mock);
+        return guard;
+      }
+    });
+
+  });
+
   describe('#fork()', function (){
 
     it('throws when invoked out of context', function (){


### PR DESCRIPTION
For those who prefer the fluent method API, this function grants
third-party functions similar privileges to the methods included in
Flutre by default, by allowing those functions to be called on the
Future without breaking the fluent method chain.