### PR TITLE
Async stack traces and debug mode

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,7 +28,8 @@
     "func-name-matching": 0,
     "no-console": 2,
     "eqeqeq": [2, "smart"],
-    "no-eq-null": 0
+    "no-eq-null": 0,
+    "no-param-reassign": 0
   },
   "overrides": [
     {

--- a/index.mjs
+++ b/index.mjs
@@ -50,3 +50,4 @@ export {hook} from './src/hook';
 export {node} from './src/node';
 export {parallel} from './src/parallel';
 export {tryP} from './src/try-p';
+export {debugMode} from './src/internal/debug';

--- a/scripts/test-mem
+++ b/scripts/test-mem
@@ -68,6 +68,18 @@ cases.asyncTailRecursion = function recur(){
   return async('l').race(async('r')).chain(recur);
 };
 
+//Expected to run out of memory.
+cases.debugModeSyncTailRecursion = function(){
+  Future.debugMode(true);
+  return cases.syncTailRecursion();
+};
+
+//Expected to run out of memory.
+cases.debugModeAsyncTailRecursion = function(){
+  Future.debugMode(true);
+  return cases.asyncTailRecursion();
+};
+
 var f = cases[process.argv[2]];
 
 if(typeof f !== 'function'){

--- a/src/after.mjs
+++ b/src/after.mjs
@@ -2,10 +2,13 @@ import {Future, never} from './future';
 import {show, partial1} from './internal/utils';
 import {isUnsigned} from './internal/predicates';
 import {throwInvalidArgument} from './internal/throw';
+import {captureContext} from './internal/debug';
+import {nil} from './internal/list';
 
 export function After(time, value){
   this._time = time;
   this._value = value;
+  this.context = captureContext(nil, 'a Future created with after', After);
 }
 
 After.prototype = Object.create(Future.prototype);
@@ -26,6 +29,7 @@ After.prototype.toString = function After$toString(){
 export function RejectAfter(time, value){
   this._time = time;
   this._value = value;
+  this.context = captureContext(nil, 'a Future created with rejectAfter', After);
 }
 
 RejectAfter.prototype = Object.create(Future.prototype);

--- a/src/attempt.mjs
+++ b/src/attempt.mjs
@@ -2,9 +2,12 @@ import {Future} from './future';
 import {noop, showf} from './internal/utils';
 import {isFunction} from './internal/predicates';
 import {throwInvalidArgument} from './internal/throw';
+import {nil} from './internal/list';
+import {captureContext} from './internal/debug';
 
 export function Attempt(fn){
   this._fn = fn;
+  this.context = captureContext(nil, 'a Future created with attempt/try', Attempt);
 }
 
 Attempt.prototype = Object.create(Future.prototype);

--- a/src/dispatchers/fork-catch.mjs
+++ b/src/dispatchers/fork-catch.mjs
@@ -2,7 +2,6 @@ import {isFuture} from '../future';
 import {partial1, partial2, partial3} from '../internal/utils';
 import {isFunction} from '../internal/predicates';
 import {throwInvalidArgument, throwInvalidFuture} from '../internal/throw';
-import {valueToError} from '../internal/error';
 
 export function forkCatch(f, g, h, m){
   if(!isFunction(f)) throwInvalidArgument('Future.forkCatch', 0, 'be a function', f);
@@ -12,5 +11,5 @@ export function forkCatch(f, g, h, m){
   if(!isFunction(h)) throwInvalidArgument('Future.forkCatch', 2, 'be a function', h);
   if(arguments.length === 3) return partial3(forkCatch, f, g, h);
   if(!isFuture(m)) throwInvalidFuture('Future.forkCatch', 3, m);
-  return m._interpret(function forkCatch$recover(x){ f(valueToError(x)) }, g, h);
+  return m._interpret(f, g, h);
 }

--- a/src/encase-n2.mjs
+++ b/src/encase-n2.mjs
@@ -2,17 +2,22 @@ import {Future} from './future';
 import {show, showf, partial1, partial2, noop} from './internal/utils';
 import {isFunction} from './internal/predicates';
 import {throwInvalidArgument} from './internal/throw';
+import {makeError} from './internal/error';
+import {nil} from './internal/list';
+import {captureContext} from './internal/debug';
 
 export function EncaseN2(fn, a, b){
   this._fn = fn;
   this._a = a;
   this._b = b;
+  this.context = captureContext(nil, 'a Future created with encaseN2', EncaseN2);
 }
 
 EncaseN2.prototype = Object.create(Future.prototype);
 
 EncaseN2.prototype._interpret = function EncaseN2$interpret(rec, rej, res){
   var open = false, cont = function(){ open = true };
+  var context = captureContext(this.context, 'consuming an encased Future', EncaseN2$interpret);
   try{
     this._fn(this._a, this._b, function EncaseN2$done(err, val){
       cont = err ? function EncaseN2$rej(){
@@ -27,7 +32,7 @@ EncaseN2.prototype._interpret = function EncaseN2$interpret(rec, rej, res){
       }
     });
   }catch(e){
-    rec(e);
+    rec(makeError(e, this, context));
     open = false;
     return noop;
   }

--- a/src/encase-n3.mjs
+++ b/src/encase-n3.mjs
@@ -2,18 +2,23 @@ import {Future} from './future';
 import {show, showf, partial1, partial2, partial3, noop} from './internal/utils';
 import {isFunction} from './internal/predicates';
 import {throwInvalidArgument} from './internal/throw';
+import {makeError} from './internal/error';
+import {nil} from './internal/list';
+import {captureContext} from './internal/debug';
 
 export function EncaseN3(fn, a, b, c){
   this._fn = fn;
   this._a = a;
   this._b = b;
   this._c = c;
+  this.context = captureContext(nil, 'a Future created with encaseN3', EncaseN3);
 }
 
 EncaseN3.prototype = Object.create(Future.prototype);
 
 EncaseN3.prototype._interpret = function EncaseN3$interpret(rec, rej, res){
   var open = false, cont = function(){ open = true };
+  var context = captureContext(this.context, 'consuming an encased Future', EncaseN3$interpret);
   try{
     this._fn(this._a, this._b, this._c, function EncaseN3$done(err, val){
       cont = err ? function EncaseN3$rej(){
@@ -28,7 +33,7 @@ EncaseN3.prototype._interpret = function EncaseN3$interpret(rec, rej, res){
       }
     });
   }catch(e){
-    rec(e);
+    rec(makeError(e, this, context));
     open = false;
     return noop;
   }

--- a/src/encase.mjs
+++ b/src/encase.mjs
@@ -2,10 +2,13 @@ import {Future} from './future';
 import {noop, show, showf, partial1} from './internal/utils';
 import {isFunction} from './internal/predicates';
 import {throwInvalidArgument} from './internal/throw';
+import {nil} from './internal/list';
+import {captureContext} from './internal/debug';
 
 export function Encase(fn, a){
   this._fn = fn;
   this._a = a;
+  this.context = captureContext(nil, 'a Future created with encase', Encase);
 }
 
 Encase.prototype = Object.create(Future.prototype);

--- a/src/encase2.mjs
+++ b/src/encase2.mjs
@@ -2,11 +2,14 @@ import {Future} from './future';
 import {noop, show, showf, partial1, partial2} from './internal/utils';
 import {isFunction} from './internal/predicates';
 import {throwInvalidArgument} from './internal/throw';
+import {nil} from './internal/list';
+import {captureContext} from './internal/debug';
 
 export function Encase2(fn, a, b){
   this._fn = fn;
   this._a = a;
   this._b = b;
+  this.context = captureContext(nil, 'a Future created with encase2', Encase2);
 }
 
 Encase2.prototype = Object.create(Future.prototype);

--- a/src/encase3.mjs
+++ b/src/encase3.mjs
@@ -2,12 +2,15 @@ import {Future} from './future';
 import {noop, show, showf, partial1, partial2, partial3} from './internal/utils';
 import {isFunction} from './internal/predicates';
 import {throwInvalidArgument} from './internal/throw';
+import {nil} from './internal/list';
+import {captureContext} from './internal/debug';
 
 export function Encase3(fn, a, b, c){
   this._fn = fn;
   this._a = a;
   this._b = b;
   this._c = c;
+  this.context = captureContext(nil, 'a Future created with encase3', Encase3);
 }
 
 Encase3.prototype = Object.create(Future.prototype);

--- a/src/future.mjs
+++ b/src/future.mjs
@@ -133,7 +133,6 @@ Computation.prototype._interpret = function Computation$interpret(rec, rej, res)
       }
     }) || noop;
   }catch(e){
-    open = false;
     rec(makeError(e, this, context));
     return noop;
   }
@@ -142,6 +141,7 @@ Computation.prototype._interpret = function Computation$interpret(rec, rej, res)
       'The computation was expected to return a nullary function or void\n' +
       '  Actual: ' + show(cancel)
     ), this, context));
+    return noop;
   }
   cont();
   return function Computation$cancel(){

--- a/src/internal/debug.mjs
+++ b/src/internal/debug.mjs
@@ -1,0 +1,41 @@
+import {noop} from './utils';
+import {cons, cat, nil} from './list';
+
+/* istanbul ignore next: non v8 compatibility */
+var captureStackTrace = Error.captureStackTrace || captureStackTraceFallback;
+var _debug = noop;
+
+export {captureStackTrace};
+
+export function debugMode(debug){
+  _debug = debug ? debugHandleAll : noop;
+}
+
+export function debugHandleAll(fn){
+  return fn();
+}
+
+export function debug(fn){
+  return _debug(fn);
+}
+
+export function captureContext(previous, tag, fn){
+  return debug(function debugCaptureContext(){
+    var context = {
+      tag: tag,
+      name: ' from ' + tag + ':',
+    };
+    captureStackTrace(context, fn);
+    return cat(previous, cons(context, nil));
+  }) || previous;
+}
+
+export function captureStackTraceFallback(x){
+  var e = new Error;
+  /* istanbul ignore else: non v8 compatibility */
+  if(typeof e.stack === 'string'){
+    x.stack = x.name + '\n' + e.stack.split('\n').slice(1).join('\n');
+  }else{
+    x.stack = x.name;
+  }
+}

--- a/src/internal/list.mjs
+++ b/src/internal/list.mjs
@@ -1,5 +1,3 @@
-/* eslint no-param-reassign:0 */
-
 export var nil = {head: null};
 nil.tail = nil;
 
@@ -7,6 +5,30 @@ export function isNil(list){
   return list.tail === list;
 }
 
+// cons :: (a, List a) -> List a
+//      -- O(1) append operation
 export function cons(head, tail){
   return {head: head, tail: tail};
+}
+
+// reverse :: List a -> List a
+//         -- O(n) list reversal
+export function reverse(xs){
+  var ys = nil, tail = xs;
+  while(!isNil(tail)){
+    ys = cons(tail.head, ys);
+    tail = tail.tail;
+  }
+  return ys;
+}
+
+// cat :: (List a, List a) -> List a
+//     -- O(n) list concatenation
+export function cat(xs, ys){
+  var zs = ys, tail = reverse(xs);
+  while(!isNil(tail)){
+    zs = cons(tail.head, zs);
+    tail = tail.tail;
+  }
+  return zs;
 }

--- a/src/internal/utils.mjs
+++ b/src/internal/utils.mjs
@@ -31,7 +31,3 @@ export function partial3(f, a, b, c){
 export function raise(x){
   throw x;
 }
-
-export function indent(s){
-  return '  ' + s;
-}

--- a/src/node.mjs
+++ b/src/node.mjs
@@ -2,9 +2,13 @@ import {Future} from './future';
 import {showf, noop} from './internal/utils';
 import {isFunction} from './internal/predicates';
 import {throwInvalidArgument} from './internal/throw';
+import {makeError} from './internal/error';
+import {nil} from './internal/list';
+import {captureContext} from './internal/debug';
 
 export function Node(fn){
   this._fn = fn;
+  this.context = captureContext(nil, 'a Future created with node');
 }
 
 Node.prototype = Object.create(Future.prototype);
@@ -25,7 +29,7 @@ Node.prototype._interpret = function Node$interpret(rec, rej, res){
       }
     });
   }catch(e){
-    rec(e);
+    rec(makeError(e, this, this.context));
     open = false;
     return noop;
   }

--- a/test.js
+++ b/test.js
@@ -1,5 +1,7 @@
+import './test/0.debug.test.mjs';
 import './test/0.error.test.mjs';
 import './test/0.iteration.test.mjs';
+import './test/0.list.test.mjs';
 import './test/0.predicates.test.mjs';
 import './test/0.utils.test.mjs';
 import './test/1.future.test.mjs';

--- a/test/0.debug.test.mjs
+++ b/test/0.debug.test.mjs
@@ -1,0 +1,66 @@
+import {eq, error, assertStackTrace} from './util';
+import {debugMode, debug, captureContext, captureStackTraceFallback} from '../src/internal/debug';
+import {nil} from '../src/internal/list';
+
+describe('debug', function (){
+
+  beforeEach(function (){
+    debugMode(false);
+  });
+
+  describe('debug()', function (){
+
+    it('does nothing by default', function (done){
+      var x = debug(function (){
+        done(error);
+      });
+      eq(x, undefined);
+      done();
+    });
+
+    it('runs the given function when debugMode was enabled', function (){
+      var guard = {};
+      debugMode(true);
+      var actual = debug(function (){
+        return guard;
+      });
+      eq(actual, guard);
+    });
+
+  });
+
+  describe('captureContext', function (){
+
+    it('returns previous when debugMode is default', function (){
+      var previous = {};
+      var x = captureContext(previous, 2, 3);
+      eq(x, previous);
+    });
+
+    it('returns a list with a context object', function (){
+      debugMode(true);
+      var prev = nil;
+      var tag = 'hello world';
+      var expectedName = ' from ' + tag + ':';
+      var ctx = captureContext(prev, tag);
+      eq(typeof ctx, 'object');
+      eq(ctx.tail, prev);
+      eq(typeof ctx.head, 'object');
+      eq(ctx.head.tag, tag);
+      eq(ctx.head.name, expectedName);
+      assertStackTrace(expectedName, ctx.head.stack);
+    });
+
+  });
+
+  describe('captureStackTraceFallback', function (){
+
+    it('assigns a stack trace to the given object', function (){
+      var o = {name: 'test'};
+      captureStackTraceFallback(o);
+      assertStackTrace('test', o.stack);
+    });
+
+  });
+
+});

--- a/test/0.list.test.mjs
+++ b/test/0.list.test.mjs
@@ -1,0 +1,23 @@
+import {eq} from './util';
+import {nil, cons, reverse, cat} from '../src/internal/list';
+
+describe('list', function (){
+
+  it('reverse()', function (){
+    eq(reverse(nil), nil);
+    eq(reverse(cons('a', nil)), cons('a', nil));
+    eq(reverse(cons('a', cons('b', nil))), cons('b', cons('a', nil)));
+    eq(reverse(cons('a', cons('b', cons('c', nil)))), cons('c', cons('b', cons('a', nil))));
+  });
+
+  it('cat()', function (){
+    eq(cat(nil, nil), nil);
+    eq(cat(cons('a', nil), nil), cons('a', nil));
+    eq(cat(nil, cons('a', nil)), cons('a', nil));
+    eq(
+      cat(cons('a', cons('b', nil)), cons('c', cons('d', nil))),
+      cons('a', cons('b', cons('c', cons('d', nil))))
+    );
+  });
+
+});

--- a/test/1.future.test.mjs
+++ b/test/1.future.test.mjs
@@ -142,22 +142,6 @@ describe('Future', function (){
       forkCatch(a, b, c, mock);
     });
 
-    it('ensures the recovery value has a consistent type', function (done){
-      var mock = Object.create(F.mock);
-      mock._interpret = function (rec){
-        rec(42);
-      };
-      forkCatch(function (x){
-        expect(x).to.be.an.instanceof(Error);
-        expect(x.name).to.equal('Error');
-        expect(x.message).to.equal(
-          'Non-Error occurred while running a computation for a Future:\n\n' +
-          '  42'
-        );
-        done();
-      }, U.noop, U.noop, mock);
-    });
-
   });
 
   describe('.value()', function (){
@@ -335,16 +319,6 @@ describe('Future', function (){
       expect(f).to.not.throw();
     });
 
-    it('throws when called on a crashed Future', function (){
-      var mock = Object.create(F.mock);
-      mock._interpret = function (rec){ rec(U.error) };
-      var f = function (){ return mock.fork(U.noop, U.noop) };
-      expect(f).to.throw(Error, (
-        'Error occurred while running a computation for a Future:\n\n' +
-        '  Intentional error for unit testing'
-      ));
-    });
-
     it('dispatches to #_interpret()', function (done){
       var a = function (){};
       var b = function (){};
@@ -358,6 +332,13 @@ describe('Future', function (){
       };
 
       mock.fork(a, b);
+    });
+
+    it('throws the interpretation crash value', function (){
+      var mock = Object.create(F.mock);
+      mock._interpret = function (rec){ rec(U.error) };
+      var f = function (){ return mock.fork(U.noop, U.noop) };
+      expect(f).to.throw(U.error);
     });
 
   });
@@ -408,22 +389,6 @@ describe('Future', function (){
       };
 
       mock.forkCatch(a, b, c);
-    });
-
-    it('ensures the recovery value has a consistent type', function (done){
-      var mock = Object.create(F.mock);
-      mock._interpret = function (rec){
-        rec(42);
-      };
-      mock.forkCatch(function (x){
-        expect(x).to.be.an.instanceof(Error);
-        expect(x.name).to.equal('Error');
-        expect(x.message).to.equal(
-          'Non-Error occurred while running a computation for a Future:\n\n' +
-          '  42'
-        );
-        done();
-      }, U.noop, U.noop);
     });
 
   });

--- a/test/futures.mjs
+++ b/test/futures.mjs
@@ -11,4 +11,4 @@ export var rejected = reject('rejected');
 export var resolvedSlow = after(20, 'resolvedSlow');
 export var rejectedSlow = rejectAfter(20, 'rejectedSlow');
 export var crashed = new Crashed(error);
-export var crashedSlow = after(20, null).and(new Crashed(error));
+export var crashedSlow = after(20, null).and(crashed);


### PR DESCRIPTION
Changes

- New debugging utilities allow Fluture to take snapshots of the stack.
- All Future interpretors now call the recover function with additional
  information on top of the crash value when they encounter an exception.
  This information includes stack snapshots taken at potentially
  different tick.
- Abstractions on top of these low-level interpretors use the additional
  information to form extended stack traces for the errors they create.
- A new public 'debugMode' function allows users to control whether the
  above features are activated.

----

You can test this yourself by installing this branch:

```console
$ npm i fluture-js/fluture#avaq/debug
```

Then write an `.mjs` file using ES6 imports from `fluture` and run it with:

```console
$ node --experimental-modules --no-warnings the-file.mjs
```
