### PR TITLE
Fix issue with Futures created from Promises

### DIFF
--- a/src/internal/utils.mjs
+++ b/src/internal/utils.mjs
@@ -1,5 +1,8 @@
 import show from 'sanctuary-show';
 
+/* istanbul ignore next: non v8 compatibility */
+var setImmediate = typeof setImmediate === 'undefined' ? setImmediateFallback : setImmediate;
+
 export {show};
 export function noop(){}
 export function moop(){ return this }
@@ -28,6 +31,12 @@ export function partial3(f, a, b, c){
   };
 }
 
+export function setImmediateFallback(f, x){
+  return setTimeout(f, 0, x);
+}
+
 export function raise(x){
-  throw x;
+  setImmediate(function rethrowErrorDelayedToEscapePromiseCatch(){
+    throw x;
+  });
 }

--- a/test/unit/0.utils.mjs
+++ b/test/unit/0.utils.mjs
@@ -70,4 +70,17 @@ describe('fn', function (){
 
   });
 
+  describe('.setImmediateFallback()', function (){
+
+    it('calls the function with a value in under 25ms', function (done){
+      var t = setTimeout(done, 25, new Error('Time is up'));
+      fn.setImmediateFallback(function (x){
+        expect(x).to.equal(42);
+        clearTimeout(t);
+        done();
+      }, 42);
+    });
+
+  });
+
 });


### PR DESCRIPTION
This fix makes it so when the `fork`, `value`, `done`, or `promise`
functions throw an exception as a result of the Future entering a
crashed state, the exception is thrown in the next tick.

This means that if a Promise was used anywhere in the pipeline, we can
ensure that it does not get the opportunity to catch this exception.

The reason we want to avoid this, is because the Promise continuations
are already handled by Fluture, and if the Promise catches this
exception, it will start handling it in its own way, by emitting an
unhandledRejection event on some global event emitter.

This exact issue has been fixed before, and then optimized in #150. It was later removed in #224 for the reasons listed in https://github.com/fluture-js/Fluture/pull/224#issuecomment-368235115. I now believe this was a mistake, and the benefit mentioned in that comment is too minor to weigh against the issue it creates.

