### PR TITLE
Disallow resource disposal Futures from failing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -254,9 +254,9 @@ declare module 'fluture' {
   export function go<L, R>(generator: Generator<FutureInstance<L, any>, R>): FutureInstance<L, R>
 
   /** Manage resources before and after the computation that needs them. See https://github.com/fluture-js/Fluture#hook */
-  export function hook<L, H, R>(acquire: FutureInstance<L, H>, dispose: (handle: H) => FutureInstance<L, any>, consume: (handle: H) => FutureInstance<L, R>): FutureInstance<L, R>
-  export function hook<L, H, R>(acquire: FutureInstance<L, H>, dispose: (handle: H) => FutureInstance<L, any>): (consume: (handle: H) => FutureInstance<L, R>) => FutureInstance<L, R>
-  export function hook<L, H, R>(acquire: FutureInstance<L, H>): AwaitingTwo<(handle: H) => FutureInstance<L, any>, (handle: H) => FutureInstance<L, R>, FutureInstance<L, R>>
+  export function hook<L, H, R>(acquire: FutureInstance<L, H>, dispose: (handle: H) => FutureInstance<any, any>, consume: (handle: H) => FutureInstance<L, R>): FutureInstance<L, R>
+  export function hook<L, H, R>(acquire: FutureInstance<L, H>, dispose: (handle: H) => FutureInstance<any, any>): (consume: (handle: H) => FutureInstance<L, R>) => FutureInstance<L, R>
+  export function hook<L, H, R>(acquire: FutureInstance<L, H>): AwaitingTwo<(handle: H) => FutureInstance<any, any>, (handle: H) => FutureInstance<L, R>, FutureInstance<L, R>>
 
   /** Returns true for Futures. See https://github.com/fluture-js/Fluture#isfuture */
   export function isFuture(value: any): boolean

--- a/test/unit/2.methods.mjs
+++ b/test/unit/2.methods.mjs
@@ -1,24 +1,7 @@
 import show from 'sanctuary-show';
 import {testMethod, futureArg, functionArg} from '../util/props';
-import {eq, noop, error} from '../util/util';
+import {eq, noop, error, raises} from '../util/util';
 import {mock as instance} from '../util/futures';
-
-function raises (done, fn, expected){
-  if(typeof process.rawListeners !== 'function'){
-    done();
-    return;
-  }
-
-  var listeners = process.rawListeners('uncaughtException');
-  process.removeAllListeners('uncaughtException');
-  process.once('uncaughtException', function (actual){
-    listeners.forEach(function (f){ process.on('uncaughtException', f) });
-    eq(actual, expected);
-    done();
-  });
-
-  fn();
-}
 
 describe('Future prototype', function (){
 

--- a/test/util/util.mjs
+++ b/test/util/util.mjs
@@ -36,6 +36,23 @@ export var throws = function throws (f, expected){
   throw new Error('Expected the function to throw');
 };
 
+export var raises = function raises (done, fn, expected){
+  if(typeof process.rawListeners !== 'function'){
+    done();
+    return;
+  }
+
+  var listeners = process.rawListeners('uncaughtException');
+  process.removeAllListeners('uncaughtException');
+  process.once('uncaughtException', function (actual){
+    listeners.forEach(function (f){ process.on('uncaughtException', f) });
+    eq(actual.message, expected.message);
+    done();
+  });
+
+  fn();
+};
+
 export var isDeepStrictEqual = function isDeepStrictEqual (actual, expected){
   try{
     eq(actual, expected);
@@ -64,6 +81,7 @@ export var assertIsFuture = function (x){
   eq(x instanceof Future, true);
   eq(x.constructor, Future);
   eq(type(x), Future['@@type']);
+  return true;
 };
 
 export var assertValidFuture = function (x){


### PR DESCRIPTION
This is a significant breaking change to how `hook` handles failure of resource disposal.

Prior to this change, when resource disposal failed:

- the failure state was propagated if the future had not been cancelled; or
- the failure was completely ignored if the future had been cancelled.

After this change, when resource disposal fails for whatever reason:

- a fatal error is raised, which can be handled by `forkCatch` if the future had not been cancelled; or
- a fatal error is thrown if the future had been cancelled.

The goal of this change is to be louder about non-disposed resources, and encourage programs to restart in case it happens.