### PR TITLE
Remove the fantasy-land dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "eslint-config-warp": "^3.0.0",
     "eslint-plugin-markdown": "^1.0.0-beta.7",
     "esm": "^3.0.81",
-    "fantasy-land": "^3.0.0",
     "fantasy-laws": "^1.0.1",
     "fantasy-states": "^0.2.1",
     "jsverify": "^0.8.3",

--- a/test/unit/3.of.mjs
+++ b/test/unit/3.of.mjs
@@ -1,5 +1,5 @@
 import chai from 'chai';
-import FL from 'fantasy-land';
+import {FL} from '../../src/internal/const';
 import {Future, of} from '../../index.mjs';
 import * as U from '../util/util';
 import {testFunction, anyArg} from '../util/props';


### PR DESCRIPTION
It was used only in one place, to access one string, already available elsewhere in the code base.

Closes #316