### PR TITLE
Add argument length checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
-  - "6.0.0"
-  - "6"
-  - "7"
+  - "8.0.0"
   - "8"
   - "9"
   - "10"
+  - "11"
+  - "12"
 after_success: npm run test:coverage && npm run coverage:upload

--- a/index.mjs
+++ b/index.mjs
@@ -2,7 +2,7 @@ import concurrify from 'concurrify';
 import type from 'sanctuary-type-identifiers';
 
 import {captureContext} from './src/internal/debug';
-import {invalidArgument} from './src/internal/error';
+import {invalidArgument, invalidArity} from './src/internal/error';
 import {nil} from './src/internal/list';
 import {FL} from './src/internal/const';
 
@@ -60,6 +60,7 @@ export function isParallel(x){
 }
 
 export function seq(par){
+  if(arguments.length > 1) throw invalidArity(seq, arguments);
   if(!isParallel(par)) throw invalidArgument('seq', 0, 'be a ConcurrentFuture', par);
   return par.sequential;
 }

--- a/src/after.mjs
+++ b/src/after.mjs
@@ -15,9 +15,9 @@ function alwaysNever(_){
 }
 
 export function after(time){
-  var context1 = application1(after, positiveInteger, time);
+  var context1 = application1(after, positiveInteger, arguments);
   return time === Infinity ? alwaysNever : (function after(value){
-    var context2 = application(2, after, any, value, context1);
+    var context2 = application(2, after, any, arguments, context1);
     return new After(context2, time, value);
   });
 }

--- a/src/alt.mjs
+++ b/src/alt.mjs
@@ -9,16 +9,16 @@ export var AltTransformation = createTransformation(1, 'alt', {
 
 export function alt(left){
   if(isFuture(left)){
-    var context1 = application1(alt, future, left);
+    var context1 = application1(alt, future, arguments);
     return function alt(right){
-      var context2 = application(2, alt, future, right, context1);
+      var context2 = application(2, alt, future, arguments, context1);
       return right._transform(new AltTransformation(context2, left));
     };
   }
 
-  var context = application1(alt, alternative, left);
+  var context = application1(alt, alternative, arguments);
   return function alt(right){
-    application(2, alt, alternative, right, context);
+    application(2, alt, alternative, arguments, context);
     return left[FL.alt](right);
   };
 }

--- a/src/and.mjs
+++ b/src/and.mjs
@@ -6,9 +6,9 @@ export var AndTransformation = createTransformation(1, 'and', {
 });
 
 export function and(left){
-  var context1 = application1(and, future, left);
+  var context1 = application1(and, future, arguments);
   return function and(right){
-    var context2 = application(2, and, future, right, context1);
+    var context2 = application(2, and, future, arguments, context1);
     return right._transform(new AndTransformation(context2, left));
   };
 }

--- a/src/ap.mjs
+++ b/src/ap.mjs
@@ -19,16 +19,16 @@ export var ApTransformation = createTransformation(1, 'ap', {
 
 export function ap(mx){
   if(isFuture(mx)){
-    var context1 = application1(ap, future, mx);
+    var context1 = application1(ap, future, arguments);
     return function ap(mf){
-      var context2 = application(2, ap, future, mf, context1);
+      var context2 = application(2, ap, future, arguments, context1);
       return mf._transform(new ApTransformation(context2, mx));
     };
   }
 
-  var context = application1(ap, applyArg, mx);
+  var context = application1(ap, applyArg, arguments);
   return function ap(mf){
-    application(2, ap, applyArg, mf, context);
+    application(2, ap, applyArg, arguments, context);
     return mx[FL.ap](mf);
   };
 }

--- a/src/attempt-p.mjs
+++ b/src/attempt-p.mjs
@@ -1,5 +1,5 @@
 import {encaseP} from './encase-p';
 
-export function attemptP(f){
-  return encaseP(f)(undefined);
+export function attemptP(_){
+  return encaseP.apply(this, arguments)(undefined);
 }

--- a/src/attempt.mjs
+++ b/src/attempt.mjs
@@ -1,5 +1,5 @@
 import {encase} from './encase';
 
-export function attempt(f){
-  return encase(f)(undefined);
+export function attempt(_){
+  return encase.apply(this, arguments)(undefined);
 }

--- a/src/bimap.mjs
+++ b/src/bimap.mjs
@@ -16,11 +16,11 @@ export var BimapTransformation = createTransformation(2, 'bimap', {
 });
 
 export function bimap(f){
-  var context1 = application1(bimap, func, f);
+  var context1 = application1(bimap, func, arguments);
   return function bimap(g){
-    var context2 = application(2, bimap, func, g, context1);
+    var context2 = application(2, bimap, func, arguments, context1);
     return function bimap(m){
-      var context3 = application(3, bimap, bifunctor, m, context2);
+      var context3 = application(3, bimap, bifunctor, arguments, context2);
       return isFuture(m) ?
              m._transform(new BimapTransformation(context3, f, g)) :
              m[FL.bimap](f, g);

--- a/src/both.mjs
+++ b/src/both.mjs
@@ -22,9 +22,9 @@ createParallelTransformation('both', earlyCrash, earlyReject, noop, {
 });
 
 export function both(left){
-  var context1 = application1(both, future, left);
+  var context1 = application1(both, future, arguments);
   return function both(right){
-    var context2 = application(2, both, future, right, context1);
+    var context2 = application(2, both, future, arguments, context1);
     return right._transform(new BothTransformation(context2, left));
   };
 }

--- a/src/cache.mjs
+++ b/src/cache.mjs
@@ -116,5 +116,5 @@ Cache.prototype.reset = function Cache$reset(){
 };
 
 export function cache(m){
-  return new Cache(application1(cache, future, m), m);
+  return new Cache(application1(cache, future, arguments), m);
 }

--- a/src/chain-rej.mjs
+++ b/src/chain-rej.mjs
@@ -7,9 +7,9 @@ export var ChainRejTransformation = createTransformation(1, 'chainRej', {
 });
 
 export function chainRej(f){
-  var context1 = application1(chainRej, func, f);
+  var context1 = application1(chainRej, func, arguments);
   return function chainRej(m){
-    var context2 = application(2, chainRej, future, m, context1);
+    var context2 = application(2, chainRej, future, arguments, context1);
     return m._transform(new ChainRejTransformation(context2, f));
   };
 }

--- a/src/chain.mjs
+++ b/src/chain.mjs
@@ -9,9 +9,9 @@ export var ChainTransformation = createTransformation(1, 'chain', {
 });
 
 export function chain(f){
-  var context1 = application1(chain, func, f);
+  var context1 = application1(chain, func, arguments);
   return function chain(m){
-    var context2 = application(2, chain, monad, m, context1);
+    var context2 = application(2, chain, monad, arguments, context1);
     return isFuture(m) ?
            m._transform(new ChainTransformation(context2, f)) :
            m[FL.chain](f);

--- a/src/crash.mjs
+++ b/src/crash.mjs
@@ -8,5 +8,5 @@ export var Crash = createInterpreter(1, 'crash', function Crash$interpret(rec){
 });
 
 export function crash(x){
-  return new Crash(application1(crash, any, x), x);
+  return new Crash(application1(crash, any, arguments), x);
 }

--- a/src/done.mjs
+++ b/src/done.mjs
@@ -2,12 +2,12 @@ import {application1, application, func, future} from './internal/check';
 import {raise} from './internal/utils';
 
 export function done(callback){
-  var context1 = application1(done, func, callback);
+  var context1 = application1(done, func, arguments);
   function done$res(x){
     callback(null, x);
   }
   return function done(m){
-    application(2, done, future, m, context1);
+    application(2, done, future, arguments, context1);
     return m._interpret(raise, callback, done$res);
   };
 }

--- a/src/encase-p.mjs
+++ b/src/encase-p.mjs
@@ -39,9 +39,9 @@ export var EncaseP = createInterpreter(2, 'encaseP', function EncaseP$interpret(
 });
 
 export function encaseP(f){
-  var context1 = application1(encaseP, func, f);
+  var context1 = application1(encaseP, func, arguments);
   return function encaseP(x){
-    var context2 = application(2, encaseP, any, x, context1);
+    var context2 = application(2, encaseP, any, arguments, context1);
     return new EncaseP(context2, f, x);
   };
 }

--- a/src/encase.mjs
+++ b/src/encase.mjs
@@ -10,9 +10,9 @@ export var Encase = createInterpreter(2, 'encase', function Encase$interpret(rec
 });
 
 export function encase(f){
-  var context1 = application1(encase, func, f);
+  var context1 = application1(encase, func, arguments);
   return function encase(x){
-    var context2 = application(2, encase, any, x, context1);
+    var context2 = application(2, encase, any, arguments, context1);
     return new Encase(context2, f, x);
   };
 }

--- a/src/extract-left.mjs
+++ b/src/extract-left.mjs
@@ -1,6 +1,6 @@
 import {application1, future} from './internal/check';
 
 export function extractLeft(m){
-  application1(extractLeft, future, m);
+  application1(extractLeft, future, arguments);
   return m.extractLeft();
 }

--- a/src/extract-right.mjs
+++ b/src/extract-right.mjs
@@ -1,6 +1,6 @@
 import {application1, future} from './internal/check';
 
 export function extractRight(m){
-  application1(extractRight, future, m);
+  application1(extractRight, future, arguments);
   return m.extractRight();
 }

--- a/src/fold.mjs
+++ b/src/fold.mjs
@@ -13,11 +13,11 @@ export var FoldTransformation = createTransformation(2, 'fold', {
 });
 
 export function fold(f){
-  var context1 = application1(fold, func, f);
+  var context1 = application1(fold, func, arguments);
   return function fold(g){
-    var context2 = application(2, fold, func, g, context1);
+    var context2 = application(2, fold, func, arguments, context1);
     return function fold(m){
-      var context3 = application(3, fold, future, m, context2);
+      var context3 = application(3, fold, future, arguments, context2);
       return m._transform(new FoldTransformation(context3, f, g));
     };
   };

--- a/src/fork-catch.mjs
+++ b/src/fork-catch.mjs
@@ -1,13 +1,13 @@
 import {application, application1, func, future} from './internal/check';
 
 export function forkCatch(f){
-  var context1 = application1(forkCatch, func, f);
+  var context1 = application1(forkCatch, func, arguments);
   return function forkCatch(g){
-    var context2 = application(2, forkCatch, func, g, context1);
+    var context2 = application(2, forkCatch, func, arguments, context1);
     return function forkCatch(h){
-      var context3 = application(3, forkCatch, func, h, context2);
+      var context3 = application(3, forkCatch, func, arguments, context2);
       return function forkCatch(m){
-        application(4, forkCatch, future, m, context3);
+        application(4, forkCatch, future, arguments, context3);
         return m._interpret(f, g, h);
       };
     };

--- a/src/fork.mjs
+++ b/src/fork.mjs
@@ -2,11 +2,11 @@ import {application, application1, func, future} from './internal/check';
 import {raise} from './internal/utils';
 
 export function fork(f){
-  var context1 = application1(fork, func, f);
+  var context1 = application1(fork, func, arguments);
   return function fork(g){
-    var context2 = application(2, fork, func, g, context1);
+    var context2 = application(2, fork, func, arguments, context1);
     return function fork(m){
-      application(3, fork, future, m, context2);
+      application(3, fork, future, arguments, context2);
       return m._interpret(raise, f, g);
     };
   };

--- a/src/future.mjs
+++ b/src/future.mjs
@@ -5,10 +5,11 @@ import {isFunction} from './internal/predicates';
 import {$$type} from './internal/const';
 import {nil, cons, isNil, reverse} from './internal/list';
 import type from 'sanctuary-type-identifiers';
-import {typeError, wrapException, invalidArgument} from './internal/error';
+import {typeError, wrapException, invalidArgument, invalidArity} from './internal/error';
 import {captureContext} from './internal/debug';
 
 export function Future(computation){
+  if(arguments.length > 1) throw invalidArity(Future, arguments);
   if(!isFunction(computation)) throw invalidArgument('Future', 0, 'be a Function', computation);
   return new Computation(captureContext(nil, 'first application of Future', Future), computation);
 }

--- a/src/go.mjs
+++ b/src/go.mjs
@@ -75,5 +75,5 @@ export var Go = createInterpreter(1, 'go', function Go$interpret(rec, rej, res){
 });
 
 export function go(generator){
-  return new Go(application1(go, func, generator), generator);
+  return new Go(application1(go, func, arguments), generator);
 }

--- a/src/hook.mjs
+++ b/src/hook.mjs
@@ -106,11 +106,11 @@ export var Hook = createInterpreter(3, 'hook', function Hook$interpret(rec, rej,
 });
 
 export function hook(acquire){
-  var context1 = application1(hook, future, acquire);
+  var context1 = application1(hook, future, arguments);
   return function hook(dispose){
-    var context2 = application(2, hook, func, dispose, context1);
+    var context2 = application(2, hook, func, arguments, context1);
     return function hook(consume){
-      var context3 = application(3, hook, func, consume, context2);
+      var context3 = application(3, hook, func, arguments, context2);
       return new Hook(context3, acquire, dispose, consume);
     };
   };

--- a/src/internal/check.mjs
+++ b/src/internal/check.mjs
@@ -12,7 +12,7 @@ import {
   isFunctor,
   isUnsigned
 } from './predicates';
-import {invalidArgument, invalidFutureArgument, withExtraContext} from './error';
+import {invalidArgument, invalidArity, invalidFutureArgument, withExtraContext} from './error';
 
 function alwaysTrue(){
   return true;
@@ -47,13 +47,13 @@ export var futureArray = {
   error: invalidArgumentOf('be an Array of valid Futures')
 };
 
-export function application(n, f, type, x, prev){
-  if(type.pred(x)) return captureApplicationContext(prev, n, f);
-  var e = type.error(f.name, n - 1, x);
+export function application(n, f, type, args, prev){
+  if(args.length < 2 && type.pred(args[0])) return captureApplicationContext(prev, n, f);
+  var e = args.length > 1 ? invalidArity(f, args) : type.error(f.name, n - 1, args[0]);
   captureStackTrace(e, f);
   throw withExtraContext(e, prev);
 }
 
-export function application1(f, type, x){
-  return application(1, f, type, x, nil);
+export function application1(f, type, args){
+  return application(1, f, type, args, nil);
 }

--- a/src/internal/error.mjs
+++ b/src/internal/error.mjs
@@ -4,6 +4,10 @@ import type from 'sanctuary-type-identifiers';
 import {nil, cat} from './list';
 import {captureStackTrace} from './debug';
 
+function showArg(x){
+  return show(x) + ' :: ' + type.parse(type(x)).name;
+}
+
 export function error(message){
   return new Error(message);
 }
@@ -15,7 +19,7 @@ export function typeError(message){
 export function invalidArgument(it, at, expected, actual){
   return typeError(
     it + '() expects its ' + ordinal[at] + ' argument to ' + expected + '.' +
-    '\n  Actual: ' + show(actual) + ' :: ' + type.parse(type(actual)).name
+    '\n  Actual: ' + showArg(actual)
   );
 }
 
@@ -23,6 +27,20 @@ export function invalidContext(it, actual){
   return typeError(
     it + '() was invoked outside the context of a Future. You might want to use'
   + ' a dispatcher instead\n  Called on: ' + show(actual)
+  );
+}
+
+export function invalidArity(f, args){
+  return new TypeError(
+    f.name + '() expects to be called with a single argument per invocation\n' +
+    '  Saw: ' + args.length + ' arguments' +
+    Array.prototype.slice.call(args).map(function(arg, i){
+      return '\n  ' + (
+        ordinal[i] ?
+        ordinal[i].charAt(0).toUpperCase() + ordinal[i].slice(1) :
+        'Argument ' + String(i + 1)
+      ) + ': ' + showArg(arg);
+    }).join('')
   );
 }
 

--- a/src/lastly.mjs
+++ b/src/lastly.mjs
@@ -14,9 +14,9 @@ export var LastlyTransformation = createTransformation(1, 'lastly', {
 });
 
 export function lastly(cleanup){
-  var context1 = application1(lastly, future, cleanup);
+  var context1 = application1(lastly, future, arguments);
   return function lastly(program){
-    var context2 = application(2, lastly, future, program, context1);
+    var context2 = application(2, lastly, future, arguments, context1);
     return program._transform(new LastlyTransformation(context2, cleanup));
   };
 }

--- a/src/map-rej.mjs
+++ b/src/map-rej.mjs
@@ -10,9 +10,9 @@ export var MapRejTransformation = createTransformation(1, 'mapRej', {
 });
 
 export function mapRej(f){
-  var context1 = application1(mapRej, func, f);
+  var context1 = application1(mapRej, func, arguments);
   return function mapRej(m){
-    var context2 = application(2, mapRej, future, m, context1);
+    var context2 = application(2, mapRej, future, arguments, context1);
     return m._transform(new MapRejTransformation(context2, f));
   };
 }

--- a/src/map.mjs
+++ b/src/map.mjs
@@ -12,9 +12,9 @@ export var MapTransformation = createTransformation(1, 'map', {
 });
 
 export function map(f){
-  var context1 = application1(map, func, f);
+  var context1 = application1(map, func, arguments);
   return function map(m){
-    var context2 = application(2, map, functor, m, context1);
+    var context2 = application(2, map, functor, arguments, context1);
     return isFuture(m) ?
            m._transform(new MapTransformation(context2, f)) :
            m[FL.map](f);

--- a/src/node.mjs
+++ b/src/node.mjs
@@ -29,5 +29,5 @@ export var Node = createInterpreter(1, 'node', function Node$interpret(rec, rej,
 });
 
 export function node(f){
-  return new Node(application1(node, func, f), f);
+  return new Node(application1(node, func, arguments), f);
 }

--- a/src/parallel-ap.mjs
+++ b/src/parallel-ap.mjs
@@ -22,9 +22,9 @@ createParallelTransformation('parallelAp', earlyCrash, earlyReject, noop, {
 });
 
 export function parallelAp(mx){
-  var context1 = application1(parallelAp, future, mx);
+  var context1 = application1(parallelAp, future, arguments);
   return function parallelAp(mf){
-    var context2 = application(2, parallelAp, future, mf, context1);
+    var context2 = application(2, parallelAp, future, arguments, context1);
     return mf._transform(new ParallelApTransformation(context2, mx));
   };
 }

--- a/src/parallel.mjs
+++ b/src/parallel.mjs
@@ -49,9 +49,9 @@ export var Parallel = createInterpreter(2, 'parallel', function Parallel$interpr
 var emptyArray = resolve([]);
 
 export function parallel(max){
-  var context1 = application1(parallel, positiveInteger, max);
+  var context1 = application1(parallel, positiveInteger, arguments);
   return function parallel(ms){
-    var context2 = application(2, parallel, futureArray, ms, context1);
+    var context2 = application(2, parallel, futureArray, arguments, context1);
     return ms.length === 0 ? emptyArray : new Parallel(context2, max, ms);
   };
 }

--- a/src/promise.mjs
+++ b/src/promise.mjs
@@ -1,7 +1,7 @@
 import {application1, future} from './internal/check';
 
 export function promise(m){
-  application1(promise, future, m);
+  application1(promise, future, arguments);
   return new Promise(function promise$computation(res, rej){
     m._interpret(rej, rej, res);
   });

--- a/src/race.mjs
+++ b/src/race.mjs
@@ -10,9 +10,9 @@ export var RaceTransformation =
 createParallelTransformation('race', earlyCrash, earlyReject, earlyResolve, {});
 
 export function race(left){
-  var context1 = application1(race, future, left);
+  var context1 = application1(race, future, arguments);
   return function race(right){
-    var context2 = application(2, race, future, right, context1);
+    var context2 = application(2, race, future, arguments, context1);
     return right._transform(new RaceTransformation(context2, left));
   };
 }

--- a/src/reject-after.mjs
+++ b/src/reject-after.mjs
@@ -16,9 +16,9 @@ function alwaysNever(_){
 }
 
 export function rejectAfter(time){
-  var context1 = application1(rejectAfter, positiveInteger, time);
+  var context1 = application1(rejectAfter, positiveInteger, arguments);
   return time === Infinity ? alwaysNever : (function rejectAfter(value){
-    var context2 = application(2, rejectAfter, any, value, context1);
+    var context2 = application(2, rejectAfter, any, arguments, context1);
     return new RejectAfter(context2, time, value);
   });
 }

--- a/src/reject.mjs
+++ b/src/reject.mjs
@@ -12,5 +12,5 @@ Reject.prototype.extractLeft = function Reject$extractLeft(){
 };
 
 export function reject(x){
-  return new Reject(application1(reject, any, x), x);
+  return new Reject(application1(reject, any, arguments), x);
 }

--- a/src/resolve.mjs
+++ b/src/resolve.mjs
@@ -12,5 +12,5 @@ Resolve.prototype.extractRight = function Resolve$extractRight(){
 };
 
 export function resolve(x){
-  return new Resolve(application1(resolve, any, x), x);
+  return new Resolve(application1(resolve, any, arguments), x);
 }

--- a/src/swap.mjs
+++ b/src/swap.mjs
@@ -13,6 +13,6 @@ export var SwapTransformation = createTransformation(0, 'swap', {
 });
 
 export function swap(m){
-  var context = application1(swap, future, m);
+  var context = application1(swap, future, arguments);
   return m._transform(new SwapTransformation(context));
 }

--- a/src/value.mjs
+++ b/src/value.mjs
@@ -3,9 +3,9 @@ import {error} from './internal/error';
 import {raise, show} from './internal/utils';
 
 export function value(res){
-  var context1 = application1(value, func, res);
+  var context1 = application1(value, func, arguments);
   return function value(m){
-    application(2, value, future, m, context1);
+    application(2, value, future, arguments, context1);
     function value$rej(x){
       raise(error(
         'Future#value was called on a rejected Future\n' +

--- a/test/unit/0.error.mjs
+++ b/test/unit/0.error.mjs
@@ -1,4 +1,4 @@
-import {eq, assertStackTrace, error as mockError} from '../util/util';
+import {eq, assertStackTrace, error as mockError, noop} from '../util/util';
 import {mock} from '../util/futures';
 import {namespace, name, version} from '../../src/internal/const';
 import {nil, cons, cat} from '../../src/internal/list';
@@ -7,10 +7,15 @@ import {
   typeError,
   invalidArgument,
   invalidContext,
+  invalidArity,
   invalidFutureArgument,
   wrapException,
   contextToStackTrace
 } from '../../src/internal/error';
+
+function args (){
+  return arguments;
+}
 
 describe('error', function (){
 
@@ -46,6 +51,23 @@ describe('error', function (){
       eq(invalidContext('Test', 'foo'), new TypeError(
         'Test() was invoked outside the context of a Future. You might want ' +
         'to use a dispatcher instead\n  Called on: "foo"'
+      ));
+    });
+
+  });
+
+  describe('invalidArity', function (){
+
+    it('constructs a TypeError', function (){
+      eq(invalidArity(noop, args('one', 2, 3, 4, 5, 6)), new TypeError(
+        'noop() expects to be called with a single argument per invocation\n' +
+        '  Saw: 6 arguments\n' +
+        '  First: "one" :: String\n' +
+        '  Second: 2 :: Number\n' +
+        '  Third: 3 :: Number\n' +
+        '  Fourth: 4 :: Number\n' +
+        '  Fifth: 5 :: Number\n' +
+        '  Argument 6: 6 :: Number'
       ));
     });
 

--- a/test/util/props.mjs
+++ b/test/util/props.mjs
@@ -213,6 +213,18 @@ export function testFunction (name, func, args, assert){
         ));
         return true;
       });
+      property('throws when the ' + ordinal[idx] + ' invocation has more than one argument', arg.valid, function (value){
+        throws(function (){
+          var partial = capply(func, validPriorArgs);
+          partial(value, 42);
+        }, new TypeError(
+          name + '() expects to be called with a single argument per invocation\n' +
+          '  Saw: 2 arguments\n' +
+          '  First: ' + show(value) + ' :: ' + type.parse(type(value)).name + '\n' +
+          '  Second: 42 :: Number'
+        ));
+        return true;
+      });
     }
   });
 


### PR DESCRIPTION
Now, when a function is applied with more than 1 argument, an exception
is thrown. This should aid users in avoiding accidental non-curried
function application.

```js
Future.value (console.log) (Future.after (300) (42, 43))
```
```txt
TypeError: after() expects to be called with a single argument per invocation
  Saw: 2 arguments
  First: 42 :: Number
  Second: 43 :: Number
    at repl:1:48
    at Script.runInThisContext (vm.js:119:20)
    at REPLServer.defaultEval (repl.js:332:29)
 from first application of after:
    at repl:1:36
    at Script.runInThisContext (vm.js:119:20)
    at REPLServer.defaultEval (repl.js:332:29)
```