### PR TITLE
Add testing utils to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "src",
     "cjs.js",
     "index.mjs",
-    "index.d.ts"
+    "index.d.ts",
+    "test/arbitraries.mjs",
+    "test/assertions.mjs"
   ],
   "repository": "https://github.com/fluture-js/Fluture.git",
   "scripts": {

--- a/test/arbitraries.mjs
+++ b/test/arbitraries.mjs
@@ -1,0 +1,72 @@
+import jsv from 'jsverify';
+import {Future, resolve, reject, Par, seq, extractLeft, extractRight} from '../index.mjs';
+
+const noop = () => {};
+const show = m => m.toString();
+
+export const nil = jsv.elements([null, undefined]);
+
+const immediatelyResolve = x => {
+  const m = Future((rej, res) => { setImmediate(res, x); return noop });
+  m.extractRight = () => [x];
+  return m;
+};
+
+const immediatelyReject = x => {
+  const m = Future((rej) => { setImmediate(rej, x); return noop });
+  m.extractLeft = () => [x];
+  return m;
+};
+
+export function AsyncResolvedFutureArb (arb){
+  return arb.smap(immediatelyResolve, extractRight, show);
+}
+
+export function AsyncRejectedFutureArb (arb){
+  return arb.smap(immediatelyReject, extractLeft, show);
+}
+
+export function ResolvedFutureArb (arb){
+  return arb.smap(resolve, extractRight, show);
+}
+
+export function RejectedFutureArb (arb){
+  return arb.smap(reject, extractLeft, show);
+}
+
+export function FutureArb (larb, rarb){
+  return jsv.oneof(
+    RejectedFutureArb(larb),
+    ResolvedFutureArb(rarb),
+    AsyncRejectedFutureArb(larb),
+    AsyncResolvedFutureArb(rarb)
+  );
+}
+
+export const {
+  any,
+  anyFuture,
+  anyRejectedFuture,
+  anyResolvedFuture,
+  anyNonFuture,
+  anyFunction,
+} = jsv.letrec(tie => ({
+  anyRejectedFuture: jsv.oneof(AsyncRejectedFutureArb(tie('any')), RejectedFutureArb(tie('any'))),
+  anyResolvedFuture: jsv.oneof(AsyncResolvedFutureArb(tie('any')), ResolvedFutureArb(tie('any'))),
+  anyFuture: jsv.oneof(tie('anyRejectedFuture'), tie('anyResolvedFuture')),
+  anyFunction: jsv.fn(tie('any')),
+  anyNonFuture: jsv.oneof(
+    jsv.number,
+    jsv.string,
+    jsv.bool,
+    jsv.falsy,
+    jsv.constant(new Error('Kapot')),
+    tie('anyFunction')
+  ),
+  any: jsv.oneof(
+    tie('anyNonFuture'),
+    tie('anyFuture')
+  ),
+}));
+
+export const anyParallel = anyFuture.smap(Par, seq, show);

--- a/test/assertions.mjs
+++ b/test/assertions.mjs
@@ -1,0 +1,117 @@
+import show from 'sanctuary-show';
+import type from 'sanctuary-type-identifiers';
+import {Future, isFuture} from '../index.mjs';
+import {strictEqual, deepStrictEqual} from 'assert';
+
+const states = ['pending', 'crashed', 'rejected', 'resolved'];
+
+export const equality = a => b => {
+  strictEqual(show(a), show(b));
+  deepStrictEqual(a, b);
+  return true;
+};
+
+export const future = x => {
+  equality(isFuture(x))(true);
+  equality(x instanceof Future)(true);
+  equality(x.constructor)(Future);
+  equality(type(x))(Future['@@type']);
+  return true;
+};
+
+export function makeEquivalence (equals){
+  return function equivalence (ma){
+    return function (mb){
+      let astate = 0, bstate = 0, val;
+      return new Promise(function (pass, fail){
+        future(ma);
+        future(mb);
+
+        function twice (m, x, s1, s2){
+          fail(new Error(
+            'A Future ' + states[s2] + ' after already having ' + states[s1] + '.\n' +
+            '  First: Future({ <' + states[s1] + '> ' + show(val) + ' })\n' +
+            '  Second: Future({ <' + states[s1] + '> ' + show(x) + ' })\n' +
+            '  Future: ' + m.toString()
+          ));
+        }
+
+        function assertInnerEqual (a, b){
+          if(astate === bstate){
+            if(isFuture(a) && isFuture(b)){
+              equivalence(a)(b).then(pass, fail);
+              return;
+            }
+            try {
+              equals(a)(b);
+              pass(true);
+            } catch (e){
+              inequivalent('The inner values are not equal: ' + e.message);
+            }
+          }else{
+            inequivalent(
+              'One Future ' + states[astate] + ', and the other Future' + states[bstate]
+            );
+          }
+          function inequivalent (message){
+            fail(new Error(
+              '\n    ' + ma.toString() +
+              ' :: Future({ <' + states[astate] + '> ' + show(a) + ' })' +
+              '\n    is not equivalent to:\n    ' + mb.toString() +
+              ' :: Future({ <' + states[bstate] + '> ' + show(b) + ' })\n\n' +
+              message
+            ));
+          }
+        }
+
+        ma._interpret(function (x){
+          if(astate > 0) twice(ma, x, astate, 1);
+          else {
+            astate = 1;
+            if(bstate > 0) assertInnerEqual(x, val);
+            else val = x;
+          }
+        }, function (x){
+          if(astate > 0) twice(ma, x, astate, 2);
+          else {
+            astate = 2;
+            if(bstate > 0) assertInnerEqual(x, val);
+            else val = x;
+          }
+        }, function (x){
+          if(astate > 0) twice(ma, x, astate, 3);
+          else {
+            astate = 3;
+            if(bstate > 0) assertInnerEqual(x, val);
+            else val = x;
+          }
+        });
+
+        mb._interpret(function (x){
+          if(bstate > 0) twice(mb, x, bstate, 1);
+          else {
+            bstate = 1;
+            if(astate > 0) assertInnerEqual(val, x);
+            else val = x;
+          }
+        }, function (x){
+          if(bstate > 0) twice(mb, x, bstate, 2);
+          else {
+            bstate = 2;
+            if(astate > 0) assertInnerEqual(val, x);
+            else val = x;
+          }
+        }, function (x){
+          if(bstate > 0) twice(mb, x, bstate, 3);
+          else {
+            bstate = 3;
+            if(astate > 0) assertInnerEqual(val, x);
+            else val = x;
+          }
+        });
+      });
+    };
+  };
+}
+
+export const equivalence = makeEquivalence(equality);

--- a/test/unit/3.after.mjs
+++ b/test/unit/3.after.mjs
@@ -1,5 +1,5 @@
 import {after, never} from '../../index.mjs';
-import {eq, assertValidFuture, assertResolved, failRej, failRes, test} from '../util/util.mjs';
+import {eq, assertValidFuture, assertResolved, test, error} from '../util/util.mjs';
 import {testFunction, positiveIntegerArg, anyArg} from '../util/props.mjs';
 
 testFunction('after', after, [positiveIntegerArg, anyArg], assertValidFuture);
@@ -13,7 +13,8 @@ test('resolves with the given value', function (){
 });
 
 test('clears its internal timeout when cancelled', function (done){
-  after(20)(1)._interpret(done, failRej, failRes)();
+  const fail = () => done(error);
+  after(20)(1)._interpret(done, fail, fail)();
   setTimeout(done, 25);
 });
 

--- a/test/unit/3.attempt-p.mjs
+++ b/test/unit/3.attempt-p.mjs
@@ -2,7 +2,7 @@
 
 import chai from 'chai';
 import {attemptP, map, mapRej} from '../../index.mjs';
-import {assertCrashed, assertRejected, assertResolved, assertValidFuture, error, failRej, failRes, noop, test} from '../util/util.mjs';
+import {assertCrashed, assertRejected, assertResolved, assertValidFuture, error, noop, test} from '../util/util.mjs';
 import {testFunction, functionArg} from '../util/props.mjs';
 
 var expect = chai.expect;
@@ -35,14 +35,16 @@ test('rejects with rejection reason of the returned Promise', function (){
 });
 
 test('ensures no resolution happens after cancel', function (done){
+  const fail = () => done(error);
   var actual = attemptP(function (){ return Promise.resolve(1) });
-  actual._interpret(done, failRej, failRes)();
+  actual._interpret(done, fail, fail)();
   setTimeout(done, 20);
 });
 
 test('ensures no rejection happens after cancel', function (done){
+  const fail = () => done(error);
   var actual = attemptP(function (){ return Promise.reject(1) });
-  actual._interpret(done, failRej, failRes)();
+  actual._interpret(done, fail, fail)();
   setTimeout(done, 20);
 });
 

--- a/test/unit/3.encase-p.mjs
+++ b/test/unit/3.encase-p.mjs
@@ -2,7 +2,7 @@
 
 import chai from 'chai';
 import {encaseP} from '../../index.mjs';
-import {test, assertCrashed, assertRejected, assertResolved, assertValidFuture, error, failRej, failRes, noop} from '../util/util.mjs';
+import {test, assertCrashed, assertRejected, assertResolved, assertValidFuture, error, noop} from '../util/util.mjs';
 import {testFunction, functionArg, anyArg} from '../util/props.mjs';
 
 var expect = chai.expect;
@@ -35,14 +35,16 @@ test('rejects with rejection reason of the returned Promise', function (){
 });
 
 test('ensures no resolution happens after cancel', function (done){
+  const fail = () => done(error);
   var actual = encaseP(function (x){ return Promise.resolve(x + 1) })(1);
-  actual._interpret(done, failRej, failRes)();
+  actual._interpret(done, fail, fail)();
   setTimeout(done, 20);
 });
 
 test('ensures no rejection happens after cancel', function (done){
+  const fail = () => done(error);
   var actual = encaseP(function (x){ return Promise.reject(x + 1) })(1);
-  actual._interpret(done, failRej, failRes)();
+  actual._interpret(done, fail, fail)();
   setTimeout(done, 20);
 });
 

--- a/test/unit/3.node.mjs
+++ b/test/unit/3.node.mjs
@@ -1,6 +1,6 @@
 import chai from 'chai';
 import {node} from '../../index.mjs';
-import {test, assertCrashed, assertRejected, assertResolved, assertValidFuture, error, failRej, failRes} from '../util/util.mjs';
+import {test, assertCrashed, assertRejected, assertResolved, assertValidFuture, error} from '../util/util.mjs';
 import {testFunction, functionArg} from '../util/props.mjs';
 
 var expect = chai.expect;
@@ -36,8 +36,9 @@ test('settles with the first asynchronous call to done', function (){
 });
 
 test('ensures no continuations are called after cancel', function (done){
+  const fail = () => done(error);
   var f = function (done){ return setTimeout(done, 5) };
-  node(f)._interpret(done, failRej, failRes)();
+  node(f)._interpret(done, fail, fail)();
   setTimeout(done, 20);
 });
 

--- a/test/unit/3.parallel.mjs
+++ b/test/unit/3.parallel.mjs
@@ -170,28 +170,28 @@ test('does not cancel settled computations (#123)', function (done){
   };
 
   m2._interpret = function (_, rej){
-    setTimeout(rej, 20, 2);
+    setTimeout(rej, 50, 2);
     return function (){ return done(error) };
   };
 
   parallel(2)([m1, m2])._interpret(done, noop, noop);
-  setTimeout(done, 50, null);
+  setTimeout(done, 100, null);
 });
 
 test('does not resolve after being cancelled', function (done){
   const fail = () => done(error);
   const cancel = parallel(1)([F.resolvedSlow, F.resolvedSlow])
   ._interpret(done, fail, fail);
-  setTimeout(cancel, 10);
-  setTimeout(done, 50);
+  cancel();
+  setTimeout(done, 100);
 });
 
 test('does not reject after being cancelled', function (done){
   const fail = () => done(error);
   const cancel = parallel(1)([F.rejectedSlow, F.rejectedSlow])
   ._interpret(done, fail, fail);
-  setTimeout(cancel, 10);
-  setTimeout(done, 50);
+  cancel();
+  setTimeout(done, 100);
 });
 
 test('is stack safe (#130)', function (){

--- a/test/unit/3.reject-after.mjs
+++ b/test/unit/3.reject-after.mjs
@@ -1,5 +1,5 @@
 import {rejectAfter, never} from '../../index.mjs';
-import {eq, assertValidFuture, assertRejected, failRej, failRes, test} from '../util/util.mjs';
+import {eq, assertValidFuture, assertRejected, test, error} from '../util/util.mjs';
 import {testFunction, positiveIntegerArg, anyArg} from '../util/props.mjs';
 
 testFunction('rejectAfter', rejectAfter, [positiveIntegerArg, anyArg], assertValidFuture);
@@ -13,7 +13,8 @@ test('rejects with the given value', function (){
 });
 
 test('clears its internal timeout when cancelled', function (done){
-  rejectAfter(20)(1)._interpret(done, failRej, failRes)();
+  const fail = () => done(error);
+  rejectAfter(20)(1)._interpret(done, fail, fail)();
   setTimeout(done, 25);
 });
 

--- a/test/unit/4.lastly.mjs
+++ b/test/unit/4.lastly.mjs
@@ -1,5 +1,5 @@
 import {lastly, resolve, reject, map} from '../../index.mjs';
-import {test, assertRejected, assertResolved, assertValidFuture, failRej, failRes, noop, eq} from '../util/util.mjs';
+import {test, assertRejected, assertResolved, assertValidFuture, noop, eq} from '../util/util.mjs';
 import {rejected, rejectedSlow, resolved, resolvedSlow} from '../util/futures.mjs';
 import {testFunction, futureArg} from '../util/props.mjs';
 
@@ -33,10 +33,11 @@ test('always rejects with the rejection reason of the second', function (){
 });
 
 test('does nothing after being cancelled', function (done){
-  lastly(resolved)(resolvedSlow)._interpret(done, failRej, failRes)();
-  lastly(resolvedSlow)(resolved)._interpret(done, failRej, failRes)();
-  lastly(rejected)(rejectedSlow)._interpret(done, failRej, failRes)();
-  lastly(rejectedSlow)(rejected)._interpret(done, failRej, failRes)();
+  const fail = () => fail(done);
+  lastly(resolved)(resolvedSlow)._interpret(done, fail, fail)();
+  lastly(resolvedSlow)(resolved)._interpret(done, fail, fail)();
+  lastly(rejected)(rejectedSlow)._interpret(done, fail, fail)();
+  lastly(rejectedSlow)(rejected)._interpret(done, fail, fail)();
   setTimeout(done, 25);
 });
 

--- a/test/unit/4.map-rej.mjs
+++ b/test/unit/4.map-rej.mjs
@@ -1,5 +1,5 @@
 import {mapRej} from '../../index.mjs';
-import {test, assertCrashed, assertRejected, assertResolved, assertValidFuture, bang, failRej, failRes, throwing, error, eq} from '../util/util.mjs';
+import {test, assertCrashed, assertRejected, assertResolved, assertValidFuture, bang, throwing, error, eq} from '../util/util.mjs';
 import {rejected, resolved, resolvedSlow, rejectedSlow} from '../util/futures.mjs';
 import {testFunction, functionArg, futureArg} from '../util/props.mjs';
 
@@ -14,12 +14,14 @@ test('maps the rejection branch with the given function', function (){
 });
 
 test('does not resolve after being cancelled', function (done){
-  mapRej(failRej)(resolvedSlow)._interpret(done, failRej, failRes)();
+  const fail = () => done(error);
+  mapRej(fail)(resolvedSlow)._interpret(done, fail, fail)();
   setTimeout(done, 25);
 });
 
 test('does not reject after being cancelled', function (done){
-  mapRej(failRej)(rejectedSlow)._interpret(done, failRej, failRes)();
+  const fail = () => done(error);
+  mapRej(fail)(rejectedSlow)._interpret(done, fail, fail)();
   setTimeout(done, 25);
 });
 

--- a/test/unit/4.map.mjs
+++ b/test/unit/4.map.mjs
@@ -1,6 +1,6 @@
 import Either from 'sanctuary-either';
 import {map} from '../../index.mjs';
-import {test, assertCrashed, assertRejected, assertResolved, assertValidFuture, bang, failRej, failRes, eq, throwing, error} from '../util/util.mjs';
+import {test, assertCrashed, assertRejected, assertResolved, assertValidFuture, bang, eq, throwing, error} from '../util/util.mjs';
 import {rejected, resolved, resolvedSlow, rejectedSlow} from '../util/futures.mjs';
 import {testFunction, functionArg, functorArg} from '../util/props.mjs';
 
@@ -19,12 +19,14 @@ test('maps the resolution branch with the given function', function (){
 });
 
 test('does not resolve after being cancelled', function (done){
-  map(failRej)(resolvedSlow)._interpret(done, failRej, failRes)();
+  const fail = () => done(error);
+  map(fail)(resolvedSlow)._interpret(done, fail, fail)();
   setTimeout(done, 25);
 });
 
 test('does not reject after being cancelled', function (done){
-  map(failRej)(rejectedSlow)._interpret(done, failRej, failRes)();
+  const fail = () => done(error);
+  map(fail)(rejectedSlow)._interpret(done, fail, fail)();
   setTimeout(done, 25);
 });
 

--- a/test/unit/5.chain-rec.mjs
+++ b/test/unit/5.chain-rec.mjs
@@ -2,7 +2,7 @@ import chai from 'chai';
 import {resolve, after, reject} from '../../index.mjs';
 import {chainRec} from '../../src/future.mjs';
 import {isIteration} from '../../src/internal/iteration.mjs';
-import {test, assertCrashed, assertRejected, assertResolved, error, failRej, failRes, noop} from '../util/util.mjs';
+import {test, assertCrashed, assertRejected, assertResolved, error, noop} from '../util/util.mjs';
 
 var expect = chai.expect;
 
@@ -60,14 +60,16 @@ test('responds to failure after chaining async', function (){
 });
 
 test('can be cancelled straight away', function (done){
+  const fail = () => done(error);
   chainRec(function (f, g, x){ return after(10)(g(x)) }, 1)
-  ._interpret(done, failRej, failRes)();
+  ._interpret(done, fail, fail)();
   setTimeout(done, 20);
 });
 
 test('can be cancelled after some iterations', function (done){
+  const fail = () => done(error);
   var m = chainRec(function (f, g, x){ return after(10)(x < 5 ? f(x + 1) : g(x)) }, 0);
-  var cancel = m._interpret(done, failRej, failRes);
+  var cancel = m._interpret(done, fail, fail);
   setTimeout(cancel, 25);
   setTimeout(done, 70);
 });

--- a/test/util/util.mjs
+++ b/test/util/util.mjs
@@ -15,7 +15,6 @@ export var B = function (f){ return function (g){ return function (x){ return f(
 export var K = function (x){ return function (){ return x } };
 export var T = function (x){ return function (f){ return f(x) } };
 export var error = new Error('Intentional error for unit testing');
-export var throwit = function (it){ throw it };
 export var throwing = function (){ throw error };
 
 export function test (name, impl){
@@ -81,14 +80,6 @@ export var promiseTimeout = function (t, p){
       setTimeout(rej, t, new Error(`Timeout of ${t}ms reached`));
     })
   ]);
-};
-
-export var failRes = function (x){
-  throw new Error(('Invalidly entered resolution branch with value ' + x));
-};
-
-export var failRej = function (x){
-  throw new Error(('Invalidly entered rejection branch with value ' + x));
 };
 
 export var assertIsFuture = function (x){

--- a/test/util/util.mjs
+++ b/test/util/util.mjs
@@ -1,9 +1,8 @@
 import oletus from 'oletus';
 import show from 'sanctuary-show';
-import type from 'sanctuary-type-identifiers';
-import {Future, isFuture, reject, resolve} from '../../index.mjs';
+import {reject, resolve} from '../../index.mjs';
 import {crash} from '../../src/future.mjs';
-import {strictEqual, deepStrictEqual} from 'assert';
+import * as assert from '../assertions.mjs';
 export * from '../../src/internal/predicates.mjs';
 
 export var STACKSIZE = (function r (){try{return 1 + r()}catch(e){return 1}}());
@@ -26,13 +25,7 @@ export function test (name, impl){
 }
 
 export var eq = function eq (actual, expected){
-  strictEqual(arguments.length, eq.length);
-  strictEqual(show(actual), show(expected));
-  //eslint-disable-next-line no-self-compare
-  if(actual !== actual && expected !== expected){
-    return;
-  }
-  deepStrictEqual(actual, expected);
+  assert.equality(actual)(expected);
 };
 
 export var throws = function throws (f, expected){
@@ -99,11 +92,7 @@ export var failRej = function (x){
 };
 
 export var assertIsFuture = function (x){
-  eq(isFuture(x), true);
-  eq(x instanceof Future, true);
-  eq(x.constructor, Future);
-  eq(type(x), Future['@@type']);
-  return true;
+  return assert.future(x);
 };
 
 export var assertValidFuture = function (x){
@@ -128,99 +117,16 @@ export var assertValidFuture = function (x){
   return true;
 };
 
-var states = ['pending', 'crashed', 'rejected', 'resolved'];
+export var assertEqual = function (a, b){
+  return assert.equivalence(a)(b);
+};
 
-export function makeAssertEqual (equals){
-  return function assertEqual (ma, mb){
-    return new Promise(function (pass, fail){
-      var astate = 0, bstate = 0, val;
-      assertIsFuture(ma);
-      assertIsFuture(mb);
-
-      function twice (m, x, s1, s2){
-        fail(new Error(
-          'A Future ' + states[s2] + ' after already having ' + states[s1] + '.\n' +
-          '  First: Future({ <' + states[s1] + '> ' + show(val) + ' })\n' +
-          '  Second: Future({ <' + states[s1] + '> ' + show(x) + ' })\n' +
-          '  Future: ' + m.toString()
-        ));
-      }
-
-      function assertInnerEqual (a, b){
-        if(astate === bstate){
-          if(isFuture(a) && isFuture(b)){
-            assertEqual(a, b).then(pass, fail);
-            return;
-          } else if (equals(a, b)){
-            pass(true);
-            return;
-          }
-        }
-        fail(new Error(
-          '\n    ' + ma.toString() +
-          ' :: Future({ <' + states[astate] + '> ' + show(a) + ' })' +
-          '\n    does not equal:\n    ' + mb.toString() +
-          ' :: Future({ <' + states[bstate] + '> ' + show(b) + ' })\n  '
-        ));
-      }
-
-      ma._interpret(function (x){
-        if(astate > 0) twice(ma, x, astate, 1);
-        else {
-          astate = 1;
-          if(bstate > 0) assertInnerEqual(x, val);
-          else val = x;
-        }
-      }, function (x){
-        if(astate > 0) twice(ma, x, astate, 2);
-        else {
-          astate = 2;
-          if(bstate > 0) assertInnerEqual(x, val);
-          else val = x;
-        }
-      }, function (x){
-        if(astate > 0) twice(ma, x, astate, 3);
-        else {
-          astate = 3;
-          if(bstate > 0) assertInnerEqual(x, val);
-          else val = x;
-        }
-      });
-
-      mb._interpret(function (x){
-        if(bstate > 0) twice(mb, x, bstate, 1);
-        else {
-          bstate = 1;
-          if(astate > 0) assertInnerEqual(val, x);
-          else val = x;
-        }
-      }, function (x){
-        if(bstate > 0) twice(mb, x, bstate, 2);
-        else {
-          bstate = 2;
-          if(astate > 0) assertInnerEqual(val, x);
-          else val = x;
-        }
-      }, function (x){
-        if(bstate > 0) twice(mb, x, bstate, 3);
-        else {
-          bstate = 3;
-          if(astate > 0) assertInnerEqual(val, x);
-          else val = x;
-        }
-      });
-    });
-  };
-}
-
-export var assertEqual = makeAssertEqual(isDeepStrictEqual);
-
-var assertEqualByErrorMessage = makeAssertEqual(function (a, b){
-  return a.message === b.message;
+var assertEqualByErrorMessage = assert.makeEquivalence(a => b => {
+  return assert.equality(a.message)(b.message);
 });
 
 export var assertCrashed = function (m, x){
-  return assertEqualByErrorMessage(m, crash(x));
+  return assertEqualByErrorMessage(m)(crash(x));
 };
 
 export var assertRejected = function (m, x){


### PR DESCRIPTION
This moves some of Fluture's internal testing utilities to `test/arbitraries.mjs` and `test/equivalence.mjs`, which are included in the npm module, allowing users of Fluture to write tests similar to those found in Fluture's own test suite.

The primary driver for this change right now is the creation of Fluenture. If this approach works well however, these files might be documented and versioned as all other parts of the public Fluture API.

The last commit closes #380