### PR TITLE
Improve the experience of converting a Future to JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ for sponsoring the project.
 - [How cancellation works](#cancellation)
 - [On stack safety](#stack-safety)
 - [Debugging with Fluture](#debugging)
+- [Casting Futures to String](#casting-futures-to-string)
 - [Usage with Sanctuary](#sanctuary)
 - [Using multiple versions of Fluture](#casting-futures)
 
@@ -394,9 +395,10 @@ original exception is created. Its properties are as follows:
   Error's own stack trace otherwise. If debug mode (see below) is enabled,
   additional stack traces from the steps leading up to the crash are included.
 - `future`: The instance of [`Future`](#future) that was being
-  [consumed](#consuming-futures) when the exception happened. Often printing it
-  as a String can yield useful information. You can also try to consume it in
-  isolation to better identify what's going wrong.
+  [consumed](#consuming-futures) when the exception happened. Often
+  [printing it as a String](#casting-futures-to-string) can yield useful
+  information. You can also try to consume it in isolation to better identify
+  what's going wrong.
 
 Finally, as mentioned, Fluture has a [debug mode](#debugmode) wherein
 additional contextual information across multiple JavaScript ticks is
@@ -405,6 +407,70 @@ collected, included as an extended "async stack trace" on Errors, and
 
 Debug mode can have a significant impact on performance, and uses up memory,
 so I would advise against using it in production.
+
+### Casting Futures to String
+
+There are multiple ways to print a Future to String. Let's take a simple
+computation as an example:
+
+```js
+const add = a => b => a + b;
+const eventualAnswer = ap (resolve (22)) (map (add) (resolve (20)));
+```
+
+1. Casting it to String directly by calling `String(eventualAnswer)` or
+   `eventualAnswer.toString()` will yield an approximation of the code that
+   was used to create the Future. In this case:
+
+   ```js
+   "ap (resolve (22)) (map (a => b => a + b) (resolve (20)))"
+   ```
+
+2. Casting it to String using `JSON.stringify(eventualAnswer, null, 2)` will
+   yield a kind of abstract syntax tree.
+
+   ```json
+   {
+     "$": "fluture/Future@5",
+     "kind": "interpreter",
+     "type": "transform",
+     "args": [
+       {
+         "$": "fluture/Future@5",
+         "kind": "interpreter",
+         "type": "resolve",
+         "args": [
+           20
+         ]
+       },
+       [
+         {
+           "$": "fluture/Future@5",
+           "kind": "transformation",
+           "type": "ap",
+           "args": [
+             {
+               "$": "fluture/Future@5",
+               "kind": "interpreter",
+               "type": "resolve",
+               "args": [
+                 22
+               ]
+             }
+           ]
+         },
+         {
+           "$": "fluture/Future@5",
+           "kind": "transformation",
+           "type": "map",
+           "args": [
+             null
+           ]
+         }
+       ]
+     ]
+   }
+   ```
 
 ### Sanctuary
 

--- a/src/internal/list.mjs
+++ b/src/internal/list.mjs
@@ -1,4 +1,13 @@
-export var nil = {head: null};
+export function List(head, tail){
+  this.head = head;
+  this.tail = tail;
+}
+
+List.prototype.toJSON = function(){
+  return toArray(this);
+};
+
+export var nil = new List(null, null);
 nil.tail = nil;
 
 export function isNil(list){
@@ -8,7 +17,7 @@ export function isNil(list){
 // cons :: (a, List a) -> List a
 //      -- O(1) append operation
 export function cons(head, tail){
-  return {head: head, tail: tail};
+  return new List(head, tail);
 }
 
 // reverse :: List a -> List a
@@ -31,4 +40,15 @@ export function cat(xs, ys){
     tail = tail.tail;
   }
   return zs;
+}
+
+// toArray :: List a -> Array a
+//         -- O(n) list to Array
+export function toArray(xs){
+  var tail = xs, arr = [];
+  while(!isNil(tail)){
+    arr.push(tail.head);
+    tail = tail.tail;
+  }
+  return arr;
 }

--- a/test/integration/main.mjs
+++ b/test/integration/main.mjs
@@ -1,5 +1,5 @@
-import {Future, resolve, after, chain, race, map} from '../../index.mjs';
-import {noop, error, assertResolved, eq} from '../util/util';
+import {Future, resolve, after, chain, race, map, ap} from '../../index.mjs';
+import {noop, error, assertResolved, eq, add} from '../util/util';
 import {resolved, resolvedSlow} from '../util/futures';
 
 function through (x, fs){
@@ -93,6 +93,29 @@ describe('Future in general', function (){
     var cancel = m._interpret(done, noop, noop);
     eq(i, 5);
     cancel();
+  });
+
+  it('returns source when cast to String', function (){
+    const m = ap(resolve(22))(map(add)(resolve(20)));
+    eq(
+      String(m),
+      'ap (resolve (22)) (map (function (a){ return function (b){ return a + b } }) (resolve (20)))'
+    );
+  });
+
+  it('returns an AST when cast to JSON', function (){
+    const m = ap(resolve(22))(map(add)(resolve(20)));
+    eq(
+      JSON.stringify(m),
+      '{"$":"fluture/Future@5","kind":"interpreter","type":"transform","args":[' +
+        '{"$":"fluture/Future@5","kind":"interpreter","type":"resolve","args":[20]},[' +
+          '{"$":"fluture/Future@5","kind":"transformation","type":"ap","args":[' +
+            '{"$":"fluture/Future@5","kind":"interpreter","type":"resolve","args":[22]}' +
+          ']},' +
+          '{"$":"fluture/Future@5","kind":"transformation","type":"map","args":[null]}' +
+        ']' +
+      ']}'
+    );
   });
 
 });


### PR DESCRIPTION
Since casting a Future to JSON doesn't really make sense, I've decided
to implement it as returning a kind of AST. This AST can be useful for
debugging. Since most of the scenarios where a Future is being turned
into JSON is during error handling, returning a value useful for
debugging seemed the most appropriate.

Closes #350 