### PR TITLE
Modify equivalence to be lax about fluture versions

### DIFF
--- a/test/assertions.js
+++ b/test/assertions.js
@@ -13,8 +13,6 @@ export const equality = a => b => {
 
 export const future = x => {
   equality(isFuture(x))(true);
-  equality(x instanceof Future)(true);
-  equality(x.constructor)(Future);
   equality(type(x))(Future['@@type']);
   return true;
 };


### PR DESCRIPTION
Currently two futures can only be equivalent if they have been built with the same constructor. This doesn't matter for the internal library tests however, if we start using this functions in libraries that process futures we need to relax this constraint.