### PR TITLE
Add support for sanctuary-type-identifiers 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "sequential"
   ],
   "dependencies": {
-    "concurrify": "^1.1.1",
+    "concurrify": "^2.0.0",
     "sanctuary-show": "^1.0.0",
     "sanctuary-type-identifiers": "^2.0.0"
   },

--- a/src/future.js
+++ b/src/future.js
@@ -63,6 +63,8 @@ Future['@@type'] = $$type;
 Future[FL.of] = resolve;
 Future[FL.chainRec] = chainRec;
 
+Future.prototype['@@type'] = $$type;
+
 Future.prototype['@@show'] = function Future$show(){
   return this.toString();
 };


### PR DESCRIPTION
Adds a `@@type` property to Future instances to inform libraries that use `sanctuary-type-identifiers@3` about the type identity.
