### PR TITLE
Use a conditional type to represent the return value of `map`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -131,11 +131,11 @@ declare module 'fluture' {
   export function lastly<L>(cleanup: FutureInstance<L, any>): <R>(action: FutureInstance<L, R>) => FutureInstance<L, R>
 
   /** Map over the resolution value of the given Future or ConcurrentFuture. See https://github.com/fluture-js/Fluture#map */
-  export function map<RA, RB>(mapper: (value: RA) => RB): <T>(source: T) =>
-    T extends FutureInstance<infer U, infer V> ?
-    FutureInstance<U, V> :
-    T extends ConcurrentFutureInstance<infer U, infer V> ?
-    ConcurrentFutureInstance<U, V> :
+  export function map<RA, RB>(mapper: (value: RA) => RB): <T extends FutureInstance<any, RA> | ConcurrentFutureInstance<any, RA>>(source: T) =>
+    T extends FutureInstance<infer L, RA> ?
+    FutureInstance<L, RB> :
+    T extends ConcurrentFutureInstance<infer L, RA> ?
+    ConcurrentFutureInstance<L, RB> :
     never;
 
   /** Map over the rejection reason of the given Future. See https://github.com/fluture-js/Fluture#maprej */

--- a/index.d.ts
+++ b/index.d.ts
@@ -131,10 +131,12 @@ declare module 'fluture' {
   export function lastly<L>(cleanup: FutureInstance<L, any>): <R>(action: FutureInstance<L, R>) => FutureInstance<L, R>
 
   /** Map over the resolution value of the given Future or ConcurrentFuture. See https://github.com/fluture-js/Fluture#map */
-  export function map<RA, RB>(mapper: (value: RA) => RB): {
-    <L>(source: FutureInstance<L, RA>): FutureInstance<L, RB>
-    <L>(source: ConcurrentFutureInstance<L, RA>): ConcurrentFutureInstance<L, RB>
-  }
+  export function map<RA, RB>(mapper: (value: RA) => RB): <T>(source: T) =>
+    T extends FutureInstance<infer U, infer V> ?
+    FutureInstance<U, V> :
+    T extends ConcurrentFutureInstance<infer U, infer V> ?
+    ConcurrentFutureInstance<U, V> :
+    never;
 
   /** Map over the rejection reason of the given Future. See https://github.com/fluture-js/Fluture#maprej */
   export function mapRej<LA, LB>(mapper: (reason: LA) => LB): <R>(source: FutureInstance<LA, R>) => FutureInstance<LB, R>


### PR DESCRIPTION
Although #401 solved the case for using `map` on a `ConcurrentFutureInstance`, it broke `FutureInstance#pipe(map(...))`:

```typescript
import { ConcurrentFutureInstance, FutureInstance, map } from 'fluture';

declare const x: FutureInstance<Error, number>;
declare const y: ConcurrentFutureInstance<Error, number>;
declare const double: (x: number) => number;

const v1 = map(double)(x); // ok; FutureInstance<Error, number>
const v1p = map(double)(y); // ok; ConcurrentFutureInstance<Error, number>
const v2 = x.pipe(map(double)) // error
```

This could potentially be down to TypeScript selecting the wrong overload (maybe because `ConcurrentFutureInstance` is the more restrictive type?)

So, I came up with this version instead, which uses a Conditional type to represent the mapper function instead. It's not ideal from an ergonomics perspective, as you end up with the whole conditional type appearing in Intellisense information. I've never been fond of that. But, it does fix (and preserve all type information) for the three forms above:

```typescript
import { ConcurrentFutureInstance, FutureInstance, /*map*/ } from 'fluture';

declare function map<RA, RB>(mapper: (value: RA) => RB): <T>(source: T) =>
    T extends FutureInstance<infer U, infer V> ?
    FutureInstance<U, V> :
    T extends ConcurrentFutureInstance<infer U, infer V> ?
    ConcurrentFutureInstance<U, V> :
    never;

declare const x: FutureInstance<Error, number>;
declare const y: ConcurrentFutureInstance<Error, number>;
declare const double: (x: number) => number;

const v1 = map(double)(x); // ok; FutureInstance<Error, number>
const v1p = map(double)(y); // ok; ConcurrentFutureInstance<Error, number>
const v2 = x.pipe(map(double)) // ok; FutureInstance<Error, number>
```

I did also experiment with simply swapping the order of the overloads around:

```typescript
import { ConcurrentFutureInstance, FutureInstance, /*map*/ } from 'fluture';

declare function map<RA, RB>(mapper: (value: RA) => RB): {
    <L>(source: ConcurrentFutureInstance<L, RA>): ConcurrentFutureInstance<L, RB>;
    <L>(source: FutureInstance<L, RA>): FutureInstance<L, RB>;
}

declare const x: FutureInstance<Error, number>;
declare const y: ConcurrentFutureInstance<Error, number>;
declare const double: (x: number) => number;

const v1 = map(double)(x); // ok; FutureInstance<Error, number>
const v1p = map(double)(y); // ok; ConcurrentFutureInstance<Error, number>
const v2 = x.pipe(map(double)) // almost ok; FutureInstance<unknown, number>
```

Observe that the left type of `v2` is `unknown` when it should be `Error`. I suspect this is down to that hanging `<L>` type parameter, and the only way to eliminate that (afaik) is to use a conditional type instead. Which, coincidentally, is where we came in.