### PR TITLE
Fix Generator yield type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -119,7 +119,7 @@ declare module 'fluture' {
   export function forkCatch(recover: RecoverFunction): <L>(reject: RejectFunction<L>) => <R>(resolve: ResolveFunction<R>) => (source: FutureInstance<L, R>) => Cancel
 
   /** Build a coroutine using Futures. See https://github.com/fluture-js/Fluture#go */
-  export function go<L, R>(generator: () => Generator<FutureInstance<L, any>, R>): FutureInstance<L, R>
+  export function go<L, R>(generator: () => Generator<FutureInstance<L, any>, R, any>): FutureInstance<L, R>
 
   /** Manage resources before and after the computation that needs them. See https://github.com/fluture-js/Fluture#hook */
   export function hook<L, H>(acquire: FutureInstance<L, H>): (dispose: (handle: H) => FutureInstance<any, any>) => <R>(consume: (handle: H) => FutureInstance<L, R>) => FutureInstance<L, R>


### PR DESCRIPTION
Fixes an issue where `go` can't determine the return type of a yield.

```typescript
const g = () => {
  return F.go(function*() {
    const thing: number = yield F.resolve(42)
    return F.resolve(43 + thing)
  })
}
```

([Original bug report on Gitter](https://gitter.im/fluture-js/Fluture?at=5e1d76c443c3b62d79f0d30f))