### PR TITLE
Update tests and docs for Node 14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install NodeJS
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
     - name: Install Dependencies
       run: npm install
     - name: Execute Tests

--- a/README.md
+++ b/README.md
@@ -64,13 +64,18 @@ getPackageName ('package.json')
 
 ### EcmaScript Module
 
-Fluture is written as modular JavaScript. It can be loaded directly by Node 12
-and up using `--experimental-modules`, or with the [esm loader][esm].
-Note that the ESM code lives at `fluture/index.js`, which is not the `main`
-file and must be imported explicitly.
+Fluture is written as modular JavaScript.
 
-Besides the module system, no other ES5+ features are used in Fluture's source,
-which means that no transpilation is needed after concatenation.
+- On Node 13 and up, you can load Fluture directly as shown in the example.
+- On Node 12, you'll need to run with `node --experimental-modules`.
+- On Node versions below 12, you can use the [esm loader][esm]. Alternatively,
+  you can use the [CommonJS Module](#commonjs-module).
+- Modern browsers can run Fluture directly. If you'd like to try this out,
+  I recommend installing Fluture with [Pika][] or [Snowpack][].
+- For older browsers, you can use a bundler such as [Rollup][] or WebPack.
+  Fluture doesn't use ES5+ language features, so the source does not have to
+  be transpiled. Alternatively, you can use the
+  [CommonJS Module](#commonjs-module).
 
 ```js
 import {readFile} from 'fs'
@@ -1652,6 +1657,8 @@ by Fluture to generate contextual stack traces.
 [$]:                    https://github.com/sanctuary-js/sanctuary-def
 
 [Rollup]:               https://rollupjs.org/
+[Pika]:                 https://www.pikapkg.com/
+[Snowpack]:             https://www.snowpack.dev/
 [esm]:                  https://github.com/standard-things/esm
 
 [Guide:HM]:             https://drboolean.gitbooks.io/mostly-adequate-guide/content/ch7.html

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "lint:readme": "remark --no-stdout --frail -u remark-validate-links README.md",
     "release": "xyz --edit --repo git@github.com:fluture-js/Fluture.git --tag 'X.Y.Z' --script scripts/distribute --increment",
     "test": "npm run lint && npm run lint:readme && ./scripts/test-esm && npm run test:code && npm run test:types && npm run test:build",
-    "test:code": "c8 node --experimental-modules --no-warnings -- ./node_modules/.bin/oletus test/unit/*.js test/integration/*.js test/prop/*.js",
+    "test:code": "c8 oletus test/unit/*.js test/integration/*.js test/prop/*.js",
     "test:mem": "NODE_OPTIONS='--experimental-modules --no-warnings' ./scripts/test-mem",
-    "test:build": "npm run build && node --experimental-modules --no-warnings -- ./node_modules/.bin/oletus test/build/*.js",
+    "test:build": "npm run build && oletus test/build/*.js",
     "coverage:upload": "c8 report --reporter=text-lcov > coverage.lcov && codecov",
     "coverage:report": "c8 report --reporter=html",
     "test:types": "tsc index.d.ts"


### PR DESCRIPTION
With Node 14, we finally have a Node version that runs ESM modules natively without hassle. Let's use it.