### PR TITLE
Update sanctuary-type-identifiers to version 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   ],
   "dependencies": {
     "sanctuary-show": "^2.0.0",
-    "sanctuary-type-identifiers": "^2.0.0"
+    "sanctuary-type-identifiers": "^3.0.0"
   },
   "devDependencies": {
     "c8": "^7.0.0",

--- a/src/future.js
+++ b/src/future.js
@@ -59,7 +59,13 @@ export function isFuture(x){
   return x instanceof Future || type(x) === $$type;
 }
 
+// Compliance with sanctuary-type-identifiers versions 1 and 2.
+// To prevent sanctuary-type-identifiers version 3 from identifying 'Future'
+// as being of the type denoted by $$type, we ensure that
+// Future.constructor.prototype is equal to Future.
 Future['@@type'] = $$type;
+Future.constructor = {prototype: Future};
+
 Future[FL.of] = resolve;
 Future[FL.chainRec] = chainRec;
 

--- a/src/par.js
+++ b/src/par.js
@@ -23,7 +23,12 @@ export function Par (sequential){
 var $$type = namespace + '/ConcurrentFuture@' + version;
 var zeroInstance = new ConcurrentFuture(never);
 
+// Compliance with sanctuary-type-identifiers versions 1 and 2.
+// To prevent sanctuary-type-identifiers version 3 from identifying
+// 'Par' as being of the type denoted by $$type, we ensure that
+// Par.constructor.prototype is equal to Par.
 Par['@@type'] = $$type;
+Par.constructor = {prototype: Par};
 
 Par[FL.of] = function Par$of(x){
   return new ConcurrentFuture(resolve(x));

--- a/test/arbitraries.js
+++ b/test/arbitraries.js
@@ -61,6 +61,8 @@ export const {
     jsv.bool,
     jsv.falsy,
     jsv.constant(new Error('Kapot')),
+    jsv.constant(Future),
+    jsv.constant(Par),
     tie('anyFunction')
   ),
   any: jsv.oneof(

--- a/test/unit/0.error.js
+++ b/test/unit/0.error.js
@@ -52,7 +52,7 @@ test('invalidArity constructs a TypeError', function (){
 });
 
 var mockType = function (identifier){
-  return {'constructor': {'@@type': identifier}, '@@show': function (){
+  return {'@@type': identifier, '@@show': function (){
     return 'mockType("' + identifier + '")';
   }};
 };


### PR DESCRIPTION
This update has been a long time coming. I'll explain the reason for waiting so long below, alongside the relevant diff. This update is possibly a breaking change, but I don't see yet how. Maybe @davidchambers can think of a scenario where it would break someone's code. :)

Closes #418 by supersession.