### PR TITLE
Update type identification logic to understand old Fluture versions

### DIFF
--- a/src/future.js
+++ b/src/future.js
@@ -1,6 +1,5 @@
 /*eslint no-cond-assign:0, no-constant-condition:0 */
-import type from 'sanctuary-type-identifiers';
-
+import {type, legacyType} from './internal/type.js';
 import {FL, $$type} from './internal/const.js';
 import {captureContext, captureApplicationContext, captureStackTrace} from './internal/debug.js';
 import {
@@ -56,7 +55,7 @@ export function Future(computation){
 }
 
 export function isFuture(x){
-  return x instanceof Future || type(x) === $$type;
+  return x instanceof Future || type(x) === $$type || legacyType(x) === $$type;
 }
 
 // Compliance with sanctuary-type-identifiers versions 1 and 2.

--- a/src/internal/error.js
+++ b/src/internal/error.js
@@ -1,11 +1,11 @@
 import {show} from './utils.js';
 import {ordinal, namespace, name, version} from './const.js';
-import type from 'sanctuary-type-identifiers';
+import {type, legacyType, parseType} from './type.js';
 import {nil, cat} from './list.js';
 import {captureStackTrace} from './debug.js';
 
 function showArg(x){
-  return show(x) + ' :: ' + type.parse(type(x)).name;
+  return show(x) + ' :: ' + parseType(type(x)).name;
 }
 
 export function error(message){
@@ -70,7 +70,11 @@ function invalidVersion(m, x){
 }
 
 export function invalidFuture(desc, m, s){
-  var id = type.parse(type(m));
+  var id = parseType(type(m));
+  var legacyId = parseType(legacyType(m));
+  if(id.name !== name && legacyId.name === name){
+    id = legacyId;
+  }
   var info = id.name === name ? '\n' + (
     id.namespace !== namespace ? invalidNamespace(m, id.namespace)
   : id.version !== version ? invalidVersion(m, id.version)

--- a/src/internal/type.js
+++ b/src/internal/type.js
@@ -1,0 +1,29 @@
+import type from 'sanctuary-type-identifiers';
+
+export var parseType = type.parse;
+
+export {type};
+
+// Copyright (c) 2017 Sanctuary
+//
+// Permission is hereby granted, free of charge, to any person
+// obtaining a copy of this software and associated documentation
+// files (the "Software"), to deal in the Software without
+// restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+var $$type = '@@type';
+export function legacyType(x){
+  return x != null &&
+         x.constructor != null &&
+         x.constructor.prototype !== x &&
+         typeof x.constructor[$$type] === 'string' ?
+    x.constructor[$$type] :
+    Object.prototype.toString.call(x).slice('[object '.length, -']'.length);
+}
+// End copyright

--- a/src/par.js
+++ b/src/par.js
@@ -1,5 +1,4 @@
-import type from 'sanctuary-type-identifiers';
-
+import {type, legacyType} from './internal/type.js';
 import {FL, namespace, version} from './internal/const.js';
 import {invalidFutureArgument} from './internal/error.js';
 import {captureContext} from './internal/debug.js';
@@ -80,5 +79,5 @@ Par.prototype[FL.alt] = function Par$FL$alt(other){
 };
 
 export function isParallel(x){
-  return x instanceof ConcurrentFuture || type(x) === $$type;
+  return x instanceof ConcurrentFuture || type(x) === $$type || legacyType(x) === $$type;
 }

--- a/test/unit/0.error.js
+++ b/test/unit/0.error.js
@@ -57,61 +57,72 @@ var mockType = function (identifier){
   }};
 };
 
+var mockLegacyType = function (identifier){
+  return {'constructor': {'@@type': identifier}, '@@show': function (){
+    return 'mockType("' + identifier + '")';
+  }};
+};
+
 test('invalidFutureArgument warns us when nothing seems wrong', function (){
-  var actual = invalidFutureArgument('Foo', 0, mockType(namespace + '/' + name + '@' + version));
-  eq(actual, new TypeError(
+  var expected = new TypeError(
     'Foo() expects its first argument to be a valid Future.\n' +
     'Nothing seems wrong. Contact the Fluture maintainers.\n' +
     '  Actual: mockType("fluture/Future@5") :: Future'
-  ));
+  );
+  eq(invalidFutureArgument('Foo', 0, mockType(namespace + '/' + name + '@' + version)), expected);
+  eq(invalidFutureArgument('Foo', 0, mockLegacyType(namespace + '/' + name + '@' + version)), expected);
 });
 
 test('invalidFutureArgument warns us about Futures from other sources', function (){
-  var actual = invalidFutureArgument('Foo', 0, mockType('bobs-tinkershop/' + name + '@' + version));
-  eq(actual, new TypeError(
+  var expected = new TypeError(
     'Foo() expects its first argument to be a valid Future.\n' +
     'The Future was not created by fluture. ' +
     'Make sure you transform other Futures to fluture Futures. ' +
     'Got a Future from bobs-tinkershop.\n' +
     '  See: https://github.com/fluture-js/Fluture#casting-futures\n' +
     '  Actual: mockType("bobs-tinkershop/Future@5") :: Future'
-  ));
+  );
+  eq(invalidFutureArgument('Foo', 0, mockType('bobs-tinkershop/' + name + '@' + version)), expected);
+  eq(invalidFutureArgument('Foo', 0, mockLegacyType('bobs-tinkershop/' + name + '@' + version)), expected);
 });
 
 test('invalidFutureArgument warns us about Futures from unnamed sources', function (){
-  var actual = invalidFutureArgument('Foo', 0, mockType(name));
-  eq(actual, new TypeError(
+  var expected = new TypeError(
     'Foo() expects its first argument to be a valid Future.\n' +
     'The Future was not created by fluture. ' +
     'Make sure you transform other Futures to fluture Futures. ' +
     'Got an unscoped Future.\n' +
     '  See: https://github.com/fluture-js/Fluture#casting-futures\n' +
     '  Actual: mockType("Future") :: Future'
-  ));
+  );
+  eq(invalidFutureArgument('Foo', 0, mockType(name)), expected);
+  eq(invalidFutureArgument('Foo', 0, mockLegacyType(name)), expected);
 });
 
 test('invalidFutureArgument warns about older versions', function (){
-  var actual = invalidFutureArgument('Foo', 0, mockType(namespace + '/' + name + '@' + (version - 1)));
-  eq(actual, new TypeError(
+  var expected = new TypeError(
     'Foo() expects its first argument to be a valid Future.\n' +
     'The Future was created by an older version of fluture. ' +
     'This means that one of the sources which creates Futures is outdated. ' +
     'Update this source, or transform its created Futures to be compatible.\n' +
     '  See: https://github.com/fluture-js/Fluture#casting-futures\n' +
     '  Actual: mockType("fluture/Future@4") :: Future'
-  ));
+  );
+  eq(invalidFutureArgument('Foo', 0, mockType(namespace + '/' + name + '@' + (version - 1))), expected);
+  eq(invalidFutureArgument('Foo', 0, mockLegacyType(namespace + '/' + name + '@' + (version - 1))), expected);
 });
 
 test('invalidFutureArgument warns about newer versions', function (){
-  var actual = invalidFutureArgument('Foo', 0, mockType(namespace + '/' + name + '@' + (version + 1)));
-  eq(actual, new TypeError(
+  var expected = new TypeError(
     'Foo() expects its first argument to be a valid Future.\n' +
     'The Future was created by a newer version of fluture. ' +
     'This means that one of the sources which creates Futures is outdated. ' +
     'Update this source, or transform its created Futures to be compatible.\n' +
     '  See: https://github.com/fluture-js/Fluture#casting-futures\n' +
     '  Actual: mockType("fluture/Future@6") :: Future'
-  ));
+  );
+  eq(invalidFutureArgument('Foo', 0, mockType(namespace + '/' + name + '@' + (version + 1))), expected);
+  eq(invalidFutureArgument('Foo', 0, mockLegacyType(namespace + '/' + name + '@' + (version + 1))), expected);
 });
 
 test('wrapException converts any value to an Error', function (){


### PR DESCRIPTION
Fluture allows multiple different versions of itself to interact. Historically, whenever a new version of Fluture came out that wouldn't be able to interact with older versions of itself, it would be released as a major new version.

Recently Fluture updated its type identification logic from using sanctuary-type-identifiers 2 to sanctuary-type-identifiers 3. See #399 and #425.

This means that newer versions of Fluture wouldn't understand that they can interact with instances created using older versions of Fluture, and that would be a breaking change.

To prevent it from being a breaking change, this PR adds a fallback for the type identification logic to still be able to identify instances of Future created by older versions of Fluture.