### PR TITLE
Include copyright licenses in bundled distributions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 The MIT License (MIT)
-Copyright (c) 2018 Aldwin Vlasblom
+Copyright (c) 2020 Aldwin Vlasblom
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/rollup.config.dist.js
+++ b/rollup.config.dist.js
@@ -1,14 +1,31 @@
-/* global process require */
+/* global process require Set */
 
+import {readFileSync} from 'fs';
 import node from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 
 var pkg = require('./package.json');
 
+var dependencies = pkg => {
+  var deps = Object.keys(pkg.dependencies || {}).concat(Object.keys(pkg.peerDependencies || {}));
+  return Array.from(new Set(deps.concat(deps.flatMap(dependency => (
+    dependencies(require(`${dependency}/package.json`))
+  )))));
+};
+
 var banner = `/**
  * Fluture bundled; version ${process.env.VERSION || `${pkg.version} (dirty)`}
  */
 `;
+
+var footer = `/** Fluture license
+
+${readFileSync('./LICENSE')}*/
+
+${dependencies(pkg).map(dependency => `/** ${dependency} license
+
+${readFileSync(`./node_modules/${dependency}/LICENSE`)}*/`
+).join('\n\n')}`;
 
 var typeref = `/// <reference types="https://cdn.jsdelivr.net/gh/fluture-js/Fluture@${
   process.env.VERSION || pkg.version
@@ -19,6 +36,7 @@ export default [{
   plugins: [node(), commonjs({include: 'node_modules/**'})],
   output: {
     banner: banner,
+    footer: footer,
     format: 'iife',
     name: 'Fluture',
     file: 'dist/bundle.js'
@@ -28,6 +46,7 @@ export default [{
   plugins: [node(), commonjs({include: 'node_modules/**'})],
   output: {
     banner: `${banner}\n${typeref}\n`,
+    footer: footer,
     format: 'es',
     file: 'dist/module.js'
   }


### PR DESCRIPTION
Fluture distributes several bundles which include its dependencies.

Each of these dependencies are licensed under the MIT license (thank you @davidchambers), so I am allowed to redistribute them.

There is one condition though, and that is that I include the copyright notice in these distributions, which I haven't (sorry @davidchambers).

This PR rectifies that.