### PR TITLE
Add branch awareness to TypeScript types (strict)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,6 +38,8 @@ export type ConcurrentResolved<T> = ConcurrentFutureInstance<never, T>;
 
 export type ConcurrentUncertain<L, R> = ConcurrentFutureInstance<L, R>;
 
+export type AnyConcurrent = ConcurrentFutureInstance<unknown, unknown>;
+
 export interface ConcurrentFutureInstance<L, R> extends Functor<R> {
   sequential: FutureInstance<L, R>
   'fantasy-land/ap'<A, B>(this: ConcurrentFutureInstance<L, (value: A) => B>, right: ConcurrentFutureInstance<L, A>): ConcurrentFutureInstance<L, B>
@@ -52,6 +54,8 @@ export type Rejected<T> = FutureInstance<T, never>;
 export type Resolved<T> = FutureInstance<never, T>;
 
 export type Uncertain<L, R> = FutureInstance<L, R>;
+
+export type AnyFuture = FutureInstance<unknown, unknown>;
 
 export interface FutureInstance<L, R> extends Functor<R> {
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -30,12 +30,20 @@ export interface Functor<A> {
 
 type Mapped<F extends Functor<unknown>, B> = ReturnType<(F & { [$T]: B })['fantasy-land/map']>
 
+export type ConcurrentRejected<T> = ConcurrentFutureInstance<T, never>;
+
+export type ConcurrentResolved<T> = ConcurrentFutureInstance<never, T>;
+
 export interface ConcurrentFutureInstance<L, R> extends Functor<R> {
   sequential: FutureInstance<L, R>
   'fantasy-land/ap'<A, B>(this: ConcurrentFutureInstance<L, (value: A) => B>, right: ConcurrentFutureInstance<L, A>): ConcurrentFutureInstance<L, B>
   'fantasy-land/map'<RB extends this[typeof $T]>(mapper: (value: R) => RB): ConcurrentFutureInstance<L, RB>
   'fantasy-land/alt'(right: ConcurrentFutureInstance<L, R>): ConcurrentFutureInstance<L, R>
 }
+
+export type Rejected<T> = FutureInstance<T, never>;
+
+export type Resolved<T> = FutureInstance<never, T>;
 
 export interface FutureInstance<L, R> extends Functor<R> {
 
@@ -60,7 +68,7 @@ export interface FutureInstance<L, R> extends Functor<R> {
 }
 
 /** Creates a Future which resolves after the given duration with the given value. See https://github.com/fluture-js/Fluture#after */
-export function after(duration: number): <R>(value: R) => FutureInstance<never, R>
+export function after(duration: number): <R>(value: R) => Resolved<R>
 
 /** Logical and for Futures. See https://github.com/fluture-js/Fluture#and */
 export function and<L, R>(left: FutureInstance<L, R>): (right: FutureInstance<L, any>) => FutureInstance<L, R>
@@ -120,7 +128,7 @@ export function extractLeft<L, R>(source: FutureInstance<L, R>): Array<L>
 export function extractRight<L, R>(source: FutureInstance<L, R>): Array<R>
 
 /** Coalesce both branches into the resolution branch. See https://github.com/fluture-js/Fluture#coalesce */
-export function coalesce<LA, R>(lmapper: (left: LA) => R): <RA>(rmapper: (right: RA) => R) => (source: FutureInstance<LA, RA>) => FutureInstance<never, R>
+export function coalesce<LA, R>(lmapper: (left: LA) => R): <RA>(rmapper: (right: RA) => R) => (source: FutureInstance<LA, RA>) => Resolved<R>
 
 /** Fork the given Future into the given continuations. See https://github.com/fluture-js/Fluture#fork */
 export function fork<L>(reject: RejectFunction<L>): <R>(resolve: ResolveFunction<R>) => (source: FutureInstance<L, R>) => Cancel
@@ -153,13 +161,13 @@ export const map: {
 export function mapRej<LA, LB>(mapper: (reason: LA) => LB): <R>(source: FutureInstance<LA, R>) => FutureInstance<LB, R>
 
 /** A Future that never settles. See https://github.com/fluture-js/Fluture#never */
-export var never: FutureInstance<never, never>
+export var never: Resolved<never>
 
 /** Create a Future using a provided Node-style callback. See https://github.com/fluture-js/Fluture#node */
 export function node<L, R>(fn: (done: Nodeback<L, R>) => void): FutureInstance<L, R>
 
 /** Create a Future with the given resolution value. See https://github.com/fluture-js/Fluture#of */
-export function resolve<R>(value: R): FutureInstance<never, R>
+export function resolve<R>(value: R): Resolved<R>
 
 /** Run an Array of Futures in parallel, under the given concurrency limit. See https://github.com/fluture-js/Fluture#parallel */
 export function parallel(concurrency: number): <L, R>(futures: Array<FutureInstance<L, R>>) => FutureInstance<L, Array<R>>
@@ -171,10 +179,10 @@ export function promise<R>(source: FutureInstance<Error, R>): Promise<R>
 export function race<L, R>(left: FutureInstance<L, R>): (right: FutureInstance<L, R>) => FutureInstance<L, R>
 
 /** Create a Future with the given rejection reason. See https://github.com/fluture-js/Fluture#reject */
-export function reject<L>(reason: L): FutureInstance<L, never>
+export function reject<L>(reason: L): Rejected<L>
 
 /** Creates a Future which rejects after the given duration with the given reason. See https://github.com/fluture-js/Fluture#rejectafter */
-export function rejectAfter(duration: number): <L>(reason: L) => FutureInstance<L, never>
+export function rejectAfter(duration: number): <L>(reason: L) => Rejected<L>
 
 /** Convert a ConcurrentFuture to a regular Future. See https://github.com/fluture-js/Fluture#concurrentfuture */
 export function seq<L, R>(source: ConcurrentFutureInstance<L, R>): FutureInstance<L, R>
@@ -183,7 +191,7 @@ export function seq<L, R>(source: ConcurrentFutureInstance<L, R>): FutureInstanc
 export function swap<L, R>(source: FutureInstance<L, R>): FutureInstance<R, L>
 
 /** Fork the Future into the given continuation. See https://github.com/fluture-js/Fluture#value */
-export function value<R>(resolve: ResolveFunction<R>): (source: FutureInstance<never, R>) => Cancel
+export function value<R>(resolve: ResolveFunction<R>): (source: Resolved<R>) => Cancel
 
 /** Enable or disable debug mode. See https://github.com/fluture-js/Fluture#debugmode */
 export function debugMode(debug: boolean): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -86,10 +86,38 @@ export function after(duration: number): <R>(value: R) => Resolved<R>
 export function and<L, R>(left: FutureInstance<L, R>): (right: FutureInstance<L, any>) => FutureInstance<L, R>
 
 /** Logical or for Futures. See https://github.com/fluture-js/Fluture#alt */
-export function alt<L, R>(left: FutureInstance<L, R>): (right: FutureInstance<L, R>) => FutureInstance<L, R>
+export const alt: {
+  <F extends AnyFuture, S extends AnyFuture>(second: F extends Never ? S : never): (first: F) => Never
+  <F extends AnyFuture, S extends AnyFuture>(second: F extends Rejected<unknown> ? S : never): (first: F) => S
+  <F extends AnyFuture, S extends AnyFuture>(second: F extends Resolved<unknown> ? S : never): (first: F) => F
 
-/** Race two ConcurrentFutures. See https://github.com/fluture-js/Fluture#alt */
-export function alt<L, R>(left: ConcurrentFutureInstance<L, R>): (right: ConcurrentFutureInstance<L, R>) => ConcurrentFutureInstance<L, R>
+  <L>(second: Rejected<L>): {
+    (first: Never): Never
+    (first: Rejected<any>): Rejected<L>
+    <R>(first: Resolved<R>): Resolved<R>
+    <R>(first: Uncertain<any, R>): Uncertain<L, R>
+  }
+
+  <L, R>(second: Uncertain<L, R>): {
+    <T>(first: Resolved<T>): Resolved<T>
+    (first: Rejected<any>): Uncertain<L, R>
+    (first: Uncertain<any, R>): Uncertain<L, R>
+  }
+
+  (second: ConcurrentNever): <L, R>(first: ConcurrentUncertain<L, R>) => ConcurrentUncertain<L, R>
+
+  <L>(second: ConcurrentRejected<L>): {
+    <R>(first: ConcurrentResolved<R>): ConcurrentUncertain<L, R>
+    <R>(first: ConcurrentUncertain<L, R>): ConcurrentUncertain<L, R>
+  }
+
+  <R>(second: ConcurrentResolved<R>): {
+    <L>(first: ConcurrentRejected<L>): ConcurrentUncertain<L, R>
+    <L>(first: ConcurrentUncertain<L, R>): ConcurrentUncertain<L, R>
+  }
+
+  <L, R>(second: ConcurrentUncertain<L, R>): (first: ConcurrentUncertain<L, R>) => ConcurrentUncertain<L, R>
+}
 
 /** Apply the function in the right Future to the value in the left Future. See https://github.com/fluture-js/Fluture#ap */
 export function ap<L, RA>(value: FutureInstance<L, RA>): <RB>(apply: FutureInstance<L, (value: RA) => RB>) => FutureInstance<L, RB>

--- a/index.d.ts
+++ b/index.d.ts
@@ -83,7 +83,17 @@ export interface FutureInstance<L, R> extends Functor<R> {
 export function after(duration: number): <R>(value: R) => Resolved<R>
 
 /** Logical and for Futures. See https://github.com/fluture-js/Fluture#and */
-export function and<L, R>(left: FutureInstance<L, R>): (right: FutureInstance<L, any>) => FutureInstance<L, R>
+export const and: {
+  <F extends AnyFuture, S extends AnyFuture>(second: F extends Never ? S : never): (first: F) => Never
+  <F extends AnyFuture, S extends AnyFuture>(second: F extends Resolved<unknown> ? S : never): (first: F) => S
+  <F extends AnyFuture, S extends AnyFuture>(second: F extends Rejected<unknown> ? S : never): (first: F) => F
+
+  <L, R>(second: Uncertain<L, R>): {
+    <T>(first: Rejected<T>): Rejected<T>
+    (first: Resolved<any>): Uncertain<L, R>
+    (first: Uncertain<L, any>): Uncertain<L, R>
+  }
+}
 
 /** Logical or for Futures. See https://github.com/fluture-js/Fluture#alt */
 export const alt: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,8 @@ export type ConcurrentRejected<T> = ConcurrentFutureInstance<T, never>;
 
 export type ConcurrentResolved<T> = ConcurrentFutureInstance<never, T>;
 
+export type ConcurrentUncertain<L, R> = ConcurrentFutureInstance<L, R>;
+
 export interface ConcurrentFutureInstance<L, R> extends Functor<R> {
   sequential: FutureInstance<L, R>
   'fantasy-land/ap'<A, B>(this: ConcurrentFutureInstance<L, (value: A) => B>, right: ConcurrentFutureInstance<L, A>): ConcurrentFutureInstance<L, B>
@@ -44,6 +46,8 @@ export interface ConcurrentFutureInstance<L, R> extends Functor<R> {
 export type Rejected<T> = FutureInstance<T, never>;
 
 export type Resolved<T> = FutureInstance<never, T>;
+
+export type Uncertain<L, R> = FutureInstance<L, R>;
 
 export interface FutureInstance<L, R> extends Functor<R> {
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -30,6 +30,8 @@ export interface Functor<A> {
 
 type Mapped<F extends Functor<unknown>, B> = ReturnType<(F & { [$T]: B })['fantasy-land/map']>
 
+export type ConcurrentNever = ConcurrentFutureInstance<never, never>;
+
 export type ConcurrentRejected<T> = ConcurrentFutureInstance<T, never>;
 
 export type ConcurrentResolved<T> = ConcurrentFutureInstance<never, T>;
@@ -42,6 +44,8 @@ export interface ConcurrentFutureInstance<L, R> extends Functor<R> {
   'fantasy-land/map'<RB extends this[typeof $T]>(mapper: (value: R) => RB): ConcurrentFutureInstance<L, RB>
   'fantasy-land/alt'(right: ConcurrentFutureInstance<L, R>): ConcurrentFutureInstance<L, R>
 }
+
+export type Never = FutureInstance<never, never>;
 
 export type Rejected<T> = FutureInstance<T, never>;
 
@@ -165,7 +169,7 @@ export const map: {
 export function mapRej<LA, LB>(mapper: (reason: LA) => LB): <R>(source: FutureInstance<LA, R>) => FutureInstance<LB, R>
 
 /** A Future that never settles. See https://github.com/fluture-js/Fluture#never */
-export var never: Resolved<never>
+export var never: Never
 
 /** Create a Future using a provided Node-style callback. See https://github.com/fluture-js/Fluture#node */
 export function node<L, R>(fn: (done: Nodeback<L, R>) => void): FutureInstance<L, R>

--- a/test/types/after.test-d.ts
+++ b/test/types/after.test-d.ts
@@ -1,0 +1,9 @@
+import {expectType} from 'tsd';
+
+import * as fl from '../../index.js';
+
+expectType<fl.Resolved<number>> (fl.after (1) (42));
+expectType<fl.Resolved<string>> (fl.after (1) ('a'));
+
+// https://github.com/microsoft/TypeScript/issues/32277
+// expectType<fl.Never> (fl.after (Infinity) ('Finally!'));

--- a/test/types/alt.test-d.ts
+++ b/test/types/alt.test-d.ts
@@ -1,0 +1,54 @@
+import {expectType, expectError} from 'tsd';
+
+import * as fl from '../../index.js';
+
+const fsn: fl.FutureInstance<string, number> = fl.resolve (42);
+const fns: fl.FutureInstance<number, string> = fl.resolve ('a');
+
+// Standard usage on Future instances.
+expectType<fl.Never> (fl.alt (fl.never) (fl.never));
+expectType<fl.Never> (fl.alt (fl.reject ('a')) (fl.never));
+expectType<fl.Never> (fl.alt (fl.resolve ('a')) (fl.never));
+expectType<fl.Never> (fl.alt (fl.never) (fl.reject ('a')));
+expectType<fl.Resolved<string>> (fl.alt (fl.never) (fl.resolve ('a')));
+expectType<fl.Resolved<number>> (fl.alt (fl.reject ('a')) (fl.resolve (42)));
+expectType<fl.Resolved<number>> (fl.alt (fl.resolve (42)) (fl.reject ('a')));
+expectType<fl.Resolved<number>> (fl.alt (fl.resolve (42)) (fl.resolve (42)));
+expectType<fl.Rejected<number>> (fl.alt (fl.reject (42)) (fl.reject (42)));
+expectType<fl.Rejected<string>> (fl.alt (fl.reject ('a')) (fl.reject (42)));
+expectType<fl.Uncertain<string, number>> (fl.alt (fsn) (fsn));
+expectType<fl.Resolved<number>> (fl.alt (fl.resolve ('a')) (fl.resolve (42)));
+expectError (fl.alt (fsn) (fns));
+
+// Usage with pipe on Future instances (https://git.io/JLx3F).
+expectType<fl.Never> ((fl.never) .pipe (fl.alt (fl.never)));
+expectType<fl.Never> ((fl.never) .pipe (fl.alt (fl.reject ('a'))));
+expectType<fl.Never> ((fl.never) .pipe (fl.alt (fl.resolve ('a'))));
+expectType<fl.Never> ((fl.reject ('a')) .pipe (fl.alt (fl.never)));
+expectType<fl.Resolved<string>> ((fl.resolve ('a')) .pipe (fl.alt (fl.never)));
+expectType<fl.Resolved<number>> ((fl.resolve (42)) .pipe (fl.alt (fl.reject ('a'))));
+expectType<fl.Resolved<number>> ((fl.reject ('a')) .pipe (fl.alt (fl.resolve (42))));
+expectType<fl.Resolved<number>> ((fl.resolve (42)) .pipe (fl.alt (fl.resolve (42))));
+expectType<fl.Rejected<number>> ((fl.reject (42)) .pipe (fl.alt (fl.reject (42))));
+expectType<fl.Rejected<string>> ((fl.reject (42)) .pipe (fl.alt (fl.reject ('a'))));
+expectType<fl.Uncertain<string, number>> ((fsn) .pipe (fl.alt (fsn)));
+expectType<fl.Resolved<number>> ((fl.resolve (42)) .pipe (fl.alt (fl.resolve ('a'))));
+expectError ((fns) .pipe (fl.alt (fsn)));
+
+const csn: fl.ConcurrentFutureInstance<string, number> = fl.Par (fl.resolve (42));
+const cns: fl.ConcurrentFutureInstance<number, string> = fl.Par (fl.resolve ('a'));
+
+// Standard usage on ConcurrentFuture instances.
+expectType<fl.ConcurrentNever> (fl.alt (fl.Par (fl.never)) (fl.Par (fl.never)));
+expectType<fl.ConcurrentRejected<string>> (fl.alt (fl.Par (fl.reject ('a'))) (fl.Par (fl.never)));
+expectType<fl.ConcurrentResolved<string>> (fl.alt (fl.Par (fl.resolve ('a'))) (fl.Par (fl.never)));
+expectType<fl.ConcurrentRejected<string>> (fl.alt (fl.Par (fl.never)) (fl.Par (fl.reject ('a'))));
+expectType<fl.ConcurrentResolved<string>> (fl.alt (fl.Par (fl.never)) (fl.Par (fl.resolve ('a'))));
+expectType<fl.ConcurrentFutureInstance<string, number>> (fl.alt (fl.Par (fl.reject ('a'))) (fl.Par (fl.resolve (42))));
+expectType<fl.ConcurrentFutureInstance<string, number>> (fl.alt (fl.Par (fl.resolve (42))) (fl.Par (fl.reject ('a'))));
+expectType<fl.ConcurrentResolved<number>> (fl.alt (fl.Par (fl.resolve (42))) (fl.Par (fl.resolve (42))));
+expectType<fl.ConcurrentRejected<number>> (fl.alt (fl.Par (fl.reject (42))) (fl.Par (fl.reject (42))));
+expectType<fl.ConcurrentUncertain<string, number>> (fl.alt (csn) (csn));
+expectError (fl.alt (fl.Par (fl.resolve ('a'))) (fl.Par (fl.resolve (42))));
+expectError (fl.alt (fl.Par (fl.reject ('a'))) (fl.Par (fl.reject (42))));
+expectError (fl.alt (csn) (cns));

--- a/test/types/and.test-d.ts
+++ b/test/types/and.test-d.ts
@@ -1,0 +1,34 @@
+import {expectType, expectError} from 'tsd';
+
+import * as fl from '../../index.js';
+
+const fsn: fl.Uncertain<string, number> = fl.resolve (42);
+const fns: fl.Uncertain<number, string> = fl.resolve ('a');
+
+// Standard usage on Future instances.
+expectType<fl.Never> (fl.and (fl.never) (fl.never));
+expectType<fl.Never> (fl.and (fl.never) (fl.resolve ('a')));
+expectType<fl.Never> (fl.and (fl.reject ('a')) (fl.never));
+expectType<fl.Never> (fl.and (fl.resolve ('a')) (fl.never));
+expectType<fl.Rejected<string>> (fl.and (fl.reject ('a')) (fl.resolve (42)));
+expectType<fl.Resolved<number>> (fl.and (fl.resolve (42)) (fl.resolve (42)));
+expectType<fl.Rejected<number>> (fl.and (fl.reject (42)) (fl.reject (42)));
+expectType<fl.Uncertain<string, number>> (fl.and (fsn) (fsn));
+expectType<fl.Rejected<string>> (fl.and (fl.never) (fl.reject ('a')));
+expectType<fl.Rejected<string>> (fl.and (fl.resolve (42)) (fl.reject ('a')));
+expectType<fl.Rejected<number>> (fl.and (fl.reject ('a')) (fl.reject (42)));
+expectError (fl.and (fsn) (fns));
+
+// Usage with pipe on Future instances (https://git.io/JLx3F).
+expectType<fl.Never> ((fl.never) .pipe (fl.and (fl.never)));
+const workaround = (fl.resolve ('a')) .pipe (fl.and (fl.never)); expectType<fl.Never> (workaround);
+expectType<fl.Never> ((fl.never) .pipe (fl.and (fl.reject ('a'))));
+expectType<fl.Never> ((fl.never) .pipe (fl.and (fl.resolve ('a'))));
+expectType<fl.Rejected<string>> ((fl.resolve (42)) .pipe (fl.and (fl.reject ('a'))));
+expectType<fl.Resolved<number>> ((fl.resolve (42)) .pipe (fl.and (fl.resolve (42))));
+expectType<fl.Rejected<number>> ((fl.reject (42)) .pipe (fl.and (fl.reject (42))));
+expectType<fl.Uncertain<string, number>> ((fsn) .pipe (fl.and (fsn)));
+expectType<fl.Rejected<string>> ((fl.reject ('a')) .pipe (fl.and (fl.never)));
+expectType<fl.Rejected<string>> ((fl.reject ('a')) .pipe (fl.and (fl.resolve (42))));
+expectType<fl.Rejected<number>> ((fl.reject (42)) .pipe (fl.and (fl.reject ('a'))));
+expectError ((fns) .pipe (fl.and (fsn)));


### PR DESCRIPTION
This is an alternative to #435 that doesn't include auto-expansion of generic types. 

----

A quick recap of auto-expansion:

**Unstrict: With auto-expansion (behaviour on `master` for `chain` and `chainRej`)**

1. `chain (_ => reject ('b')) (reject ('a'))` gets type `Future<string, never>`: _The types align._
2. `chain (_ => reject ('a')) (reject (1))` gets type `Future<number | string, never>`: _The rejection type was expanded._
3. `chain (_ => reject ('a')) (resolve (1))` gets type `Future<string, number>`: _The types were expanded with `never`, which leaves them intact._

**Strict: Without auto-expansion (behaviour on `master` for everything else)**

1. `chain (_ => reject ('b')) (reject ('a'))` gets type `Future<string, never>`: _The types align._
2. `chain (_ => reject ('a')) (reject (1))` produces a type error: _The types don't align. This is desirable behaviour, because it is more true to the behaviour in Haskell, where the rejection branch cannot change type because the monad instance is created for the unary constructor that is left after providing the first type variable._
3. `chain (_ => reject ('a')) (resolve (1))` produces a type error: _TypeScript doesn't want to assign `never` to another type. For `chain` and `chainRej` this was fixed in #374 by making those functions unstrict._

----

In #435, I had given up on the strict approach (following the trend created in #374), because I thought there's no way to get the strict behaviour while retaining the ability to `chain` (or otherwise combine) futures where the branch types don't technically conflict because the variable on one of the sides was untouched (like in examples `3` above).

The goal of this pull request is to:

- Reimplement `chain` and `chainRej` using the strict approach, getting rid of the problem highlighted by example `2`.
- Add branch awareness to all combinators. I realized this is enough to get rid of problem `3` from the strict approach, because we're no longer asking TypeScript to assign `never` to anything: Our overloads take care of any occurrence of `never` with special treatment.

----

This approach brings new problems, however. In particular, TypeScript loses type information when these functions are called indirectly, such as by `pipe`. I think this happens because TypeScript cannot infer types from overloaded functions (https://github.com/microsoft/TypeScript/issues/32418#issuecomment-516892451).

So where this approach works perfectly for statements like `and (resolve (42)) (reject ('abc'))`, it produces some `unknown` type variables when refactoring that to `reject ('abc') .pipe (and (resolve (42)))`, because `and (resolve (42))` creates an overloaded lambda, from which `pipe` cannot infer any type information.

If anyone can help with this new problem, it'll be much appreciated!