### PR TITLE
Add missing exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
       "import": "./index.js",
       "default": "./index.cjs"
     },
+    "./index.js": "./index.js",
     "./test/arbitraries.js": "./test/arbitraries.js",
     "./test/assertions.js": "./test/assertions.js"
   },

--- a/package.json
+++ b/package.json
@@ -7,8 +7,12 @@
   "types": "index.d.ts",
   "module": "index.js",
   "exports": {
-    "require": "./index.cjs",
-    "import": "./index.js"
+    ".": {
+      "require": "./index.cjs",
+      "import": "./index.js"
+    },
+    "./test/arbitraries.js": "./test/arbitraries.js",
+    "./test/assertions.js": "./test/assertions.js"
   },
   "files": [
     "src",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "require": "./index.cjs",
-      "import": "./index.js"
+      "import": "./index.js",
+      "default": "./index.cjs"
     },
     "./test/arbitraries.js": "./test/arbitraries.js",
     "./test/assertions.js": "./test/assertions.js"


### PR DESCRIPTION
While updating Momi I realized that it is not possible to deep import any file which is not exported in the `exports` object.

```text
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './test/assertions.js' is not defined by "exports"
in /home/diego/dev/fluture/momi/node_modules/fluture/package.json imported
from /home/diego/dev/fluture/momi/test/index.js
```

I have only added  `test/assertions` and `test/arbitraries` but I don't know what to do with the types.

I wouldn't export `src/*` although I am not aware if we have any important project deep importing from it.