### PR TITLE
Update chainRej example code to include the rejection

### DIFF
--- a/README.md
+++ b/README.md
@@ -992,7 +992,7 @@ Chain over the **rejection** reason of the Future. This is like
 ```js
 > fork (log ('rejection'))
 .      (log ('resolution'))
-.      (chainRej (s => resolve (`${s} But it's all good.`)))
+.      (chainRej (s => resolve (`${s} But it's all good.`)) (reject ('It broke!')))
 [resolution]: "It broke! But it's all good."
 ```
 


### PR DESCRIPTION
Update the chainRej example code to include the rejection needed to
produce the example output. The current example code will throw an error
as the third argument to fork is not a valid future.

Closes #444 