### PR TITLE
Fix TypeScript type inference for functions passed to map

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -28,7 +28,7 @@ export interface Functor<A> {
   'fantasy-land/map'<B extends this[typeof $T]>(mapper: (value: A) => B): Functor<B>
 }
 
-type Unfunctor<F extends Functor<unknown>, B> = ReturnType<(F & { [$T]: B })['fantasy-land/map']>
+type Mapped<F extends Functor<unknown>, B> = ReturnType<(F & { [$T]: B })['fantasy-land/map']>
 
 export interface ConcurrentFutureInstance<L, R> extends Functor<R> {
   sequential: FutureInstance<L, R>
@@ -145,8 +145,8 @@ export function lastly<L>(cleanup: FutureInstance<L, any>): <R>(action: FutureIn
 
 /** Map over the resolution value of the given Future or ConcurrentFuture. See https://github.com/fluture-js/Fluture#map */
 export const map: {
-  <B, F extends Functor<unknown>>(mapper: Functor<unknown> extends F ? never : (a: F extends Functor<infer A> ? A : never) => B): (source: F) => Unfunctor<F, B>
-  <A, B>(mapper: (a: A) => B): <F extends Functor<A>>(source: F) => Unfunctor<F, B>
+  <B, F extends Functor<unknown>>(mapper: Functor<unknown> extends F ? never : (a: F extends Functor<infer A> ? A : never) => B): (source: F) => Mapped<F, B>
+  <A, B>(mapper: (a: A) => B): <F extends Functor<A>>(source: F) => Mapped<F, B>
 }
 
 /** Map over the rejection reason of the given Future. See https://github.com/fluture-js/Fluture#maprej */

--- a/index.d.ts
+++ b/index.d.ts
@@ -145,8 +145,8 @@ export function lastly<L>(cleanup: FutureInstance<L, any>): <R>(action: FutureIn
 
 /** Map over the resolution value of the given Future or ConcurrentFuture. See https://github.com/fluture-js/Fluture#map */
 export const map: {
-  <B, F extends Functor<unknown>>(f: Functor<unknown> extends F ? never : (a: F extends Functor<infer A> ? A : never) => B): (source: F) => Unfunctor<F, B>
-  <A, B>(f: (a: A) => B): <F extends Functor<A>>(f: F) => Unfunctor<F, B>
+  <B, F extends Functor<unknown>>(mapper: Functor<unknown> extends F ? never : (a: F extends Functor<infer A> ? A : never) => B): (source: F) => Unfunctor<F, B>
+  <A, B>(mapper: (a: A) => B): <F extends Functor<A>>(source: F) => Unfunctor<F, B>
 }
 
 /** Map over the rejection reason of the given Future. See https://github.com/fluture-js/Fluture#maprej */

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,17 +21,19 @@ export interface Nodeback<E, R> {
   (err: E | null, value?: R): void
 }
 
+declare const $T: unique symbol
+
 export interface Functor<A> {
-  input: unknown
-  'fantasy-land/map'<B extends this['input']>(mapper: (value: A) => B): Functor<B>
+  [$T]: unknown
+  'fantasy-land/map'<B extends this[typeof $T]>(mapper: (value: A) => B): Functor<B>
 }
 
-type Unfunctor<F extends Functor<unknown>, B> = ReturnType<(F & { input: B })['fantasy-land/map']>
+type Unfunctor<F extends Functor<unknown>, B> = ReturnType<(F & { [$T]: B })['fantasy-land/map']>
 
 export interface ConcurrentFutureInstance<L, R> extends Functor<R> {
   sequential: FutureInstance<L, R>
   'fantasy-land/ap'<A, B>(this: ConcurrentFutureInstance<L, (value: A) => B>, right: ConcurrentFutureInstance<L, A>): ConcurrentFutureInstance<L, B>
-  'fantasy-land/map'<RB extends this['input']>(mapper: (value: R) => RB): ConcurrentFutureInstance<L, RB>
+  'fantasy-land/map'<RB extends this[typeof $T]>(mapper: (value: R) => RB): ConcurrentFutureInstance<L, RB>
   'fantasy-land/alt'(right: ConcurrentFutureInstance<L, R>): ConcurrentFutureInstance<L, R>
 }
 
@@ -50,7 +52,7 @@ export interface FutureInstance<L, R> extends Functor<R> {
   extractRight(): Array<R>
 
   'fantasy-land/ap'<A, B>(this: FutureInstance<L, (value: A) => B>, right: FutureInstance<L, A>): FutureInstance<L, B>
-  'fantasy-land/map'<RB extends this['input']>(mapper: (value: R) => RB): FutureInstance<L, RB>
+  'fantasy-land/map'<RB extends this[typeof $T]>(mapper: (value: R) => RB): FutureInstance<L, RB>
   'fantasy-land/alt'(right: FutureInstance<L, R>): FutureInstance<L, R>
   'fantasy-land/bimap'<LB, RB>(lmapper: (reason: L) => LB, rmapper: (value: R) => RB): FutureInstance<LB, RB>
   'fantasy-land/chain'<LB, RB>(mapper: (value: R) => FutureInstance<LB, RB>): FutureInstance<L | LB, RB>

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,20 +21,27 @@ export interface Nodeback<E, R> {
   (err: E | null, value?: R): void
 }
 
-export interface ConcurrentFutureInstance<L, R> {
+export interface Functor<A> {
+  input: unknown
+  'fantasy-land/map'<B extends this['input']>(mapper: (value: A) => B): Functor<B>
+}
+
+type Unfunctor<F extends Functor<unknown>, B> = ReturnType<(F & { input: B })['fantasy-land/map']>
+
+export interface ConcurrentFutureInstance<L, R> extends Functor<R> {
   sequential: FutureInstance<L, R>
   'fantasy-land/ap'<A, B>(this: ConcurrentFutureInstance<L, (value: A) => B>, right: ConcurrentFutureInstance<L, A>): ConcurrentFutureInstance<L, B>
-  'fantasy-land/map'<RB>(mapper: (value: R) => RB): ConcurrentFutureInstance<L, RB>
+  'fantasy-land/map'<RB extends this['input']>(mapper: (value: R) => RB): ConcurrentFutureInstance<L, RB>
   'fantasy-land/alt'(right: ConcurrentFutureInstance<L, R>): ConcurrentFutureInstance<L, R>
 }
 
-export interface FutureInstance<L, R> {
+export interface FutureInstance<L, R> extends Functor<R> {
 
   /** The Future constructor */
   constructor: FutureTypeRep
 
   /** Apply a function to this Future. See https://github.com/fluture-js/Fluture#pipe */
-  pipe<T>(fn: (future: FutureInstance<L, R>) => T): T
+  pipe<T>(fn: (future: this) => T): T
 
   /** Attempt to extract the rejection reason. See https://github.com/fluture-js/Fluture#extractleft */
   extractLeft(): Array<L>
@@ -43,7 +50,7 @@ export interface FutureInstance<L, R> {
   extractRight(): Array<R>
 
   'fantasy-land/ap'<A, B>(this: FutureInstance<L, (value: A) => B>, right: FutureInstance<L, A>): FutureInstance<L, B>
-  'fantasy-land/map'<RB>(mapper: (value: R) => RB): FutureInstance<L, RB>
+  'fantasy-land/map'<RB extends this['input']>(mapper: (value: R) => RB): FutureInstance<L, RB>
   'fantasy-land/alt'(right: FutureInstance<L, R>): FutureInstance<L, R>
   'fantasy-land/bimap'<LB, RB>(lmapper: (reason: L) => LB, rmapper: (value: R) => RB): FutureInstance<LB, RB>
   'fantasy-land/chain'<LB, RB>(mapper: (value: R) => FutureInstance<LB, RB>): FutureInstance<L | LB, RB>
@@ -135,12 +142,10 @@ export function isNever(value: any): boolean
 export function lastly<L>(cleanup: FutureInstance<L, any>): <R>(action: FutureInstance<L, R>) => FutureInstance<L, R>
 
 /** Map over the resolution value of the given Future or ConcurrentFuture. See https://github.com/fluture-js/Fluture#map */
-export function map<RA, RB>(mapper: (value: RA) => RB): <T extends FutureInstance<any, RA> | ConcurrentFutureInstance<any, RA>>(source: T) =>
-  T extends FutureInstance<infer L, RA> ?
-  FutureInstance<L, RB> :
-  T extends ConcurrentFutureInstance<infer L, RA> ?
-  ConcurrentFutureInstance<L, RB> :
-  never;
+export const map: {
+  <B, F extends Functor<unknown>>(f: Functor<unknown> extends F ? never : (a: F extends Functor<infer A> ? A : never) => B): (source: F) => Unfunctor<F, B>
+  <A, B>(f: (a: A) => B): <F extends Functor<A>>(f: F) => Unfunctor<F, B>
+}
 
 /** Map over the rejection reason of the given Future. See https://github.com/fluture-js/Fluture#maprej */
 export function mapRej<LA, LB>(mapper: (reason: LA) => LB): <R>(source: FutureInstance<LA, R>) => FutureInstance<LB, R>

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:build": "npm run build && oletus test/build/*.js",
     "coverage:upload": "c8 report --reporter=text-lcov > coverage.lcov && codecov",
     "coverage:report": "c8 report --reporter=html",
-    "test:types": "tsc index.d.ts"
+    "test:types": "tsd"
   },
   "author": "Aldwin Vlasblom <aldwin.vlasblom@gmail.com> (https://github.com/Avaq)",
   "homepage": "https://github.com/fluture-js/Fluture",
@@ -93,7 +93,11 @@
     "sanctuary-benchmark": "^1.0.0",
     "sanctuary-either": "^2.0.0",
     "sanctuary-type-classes": "^12.0.0",
+    "tsd": "^0.14.0",
     "typescript": "^4.0.2",
     "xyz": "^4.0.0"
+  },
+  "tsd": {
+    "directory": "test/types"
   }
 }

--- a/test/types/map.test-d.ts
+++ b/test/types/map.test-d.ts
@@ -19,3 +19,7 @@ expectType<fl.ConcurrentFutureInstance<string, string>> (fl.map (String) (reject
 // Usage with pipe on Future instances (https://git.io/JLx3F).
 expectType<fl.FutureInstance<never, string>> (resolved .pipe (fl.map (String)));
 expectType<fl.FutureInstance<string, string>> (rejected .pipe (fl.map (String)));
+
+// Function parameter inference from the second argument in a pipe (https://git.io/JLxsX).
+expectType<fl.FutureInstance<never, number>> (resolved .pipe (fl.map (x => x)));
+expectType<fl.FutureInstance<string, never>> (rejected .pipe (fl.map (x => x)));

--- a/test/types/map.test-d.ts
+++ b/test/types/map.test-d.ts
@@ -1,0 +1,21 @@
+import {expectType} from 'tsd';
+
+import * as fl from '../../index.js';
+
+const resolved = fl.resolve (42);
+const rejected = fl.reject ('uh-oh');
+
+const resolvedPar = fl.Par (resolved);
+const rejectedPar = fl.Par (rejected);
+
+// Standard usage on Future instances.
+expectType<fl.FutureInstance<never, string>> (fl.map (String) (resolved));
+expectType<fl.FutureInstance<string, string>> (fl.map (String) (rejected));
+
+// Standard usage on ConcurrentFuture instances.
+expectType<fl.ConcurrentFutureInstance<never, string>> (fl.map (String) (resolvedPar));
+expectType<fl.ConcurrentFutureInstance<string, string>> (fl.map (String) (rejectedPar));
+
+// Usage with pipe on Future instances (https://git.io/JLx3F).
+expectType<fl.FutureInstance<never, string>> (resolved .pipe (fl.map (String)));
+expectType<fl.FutureInstance<string, string>> (rejected .pipe (fl.map (String)));


### PR DESCRIPTION
This pull request tries to fix #455 

I've started with a [tsd](https://github.com/SamVerschueren/tsd) setup to defend against regressions to before #401 and #403. Run `npm run test:types` to check that your typings have not introduced a regression.

For context, here's the current TypeScript typings for `map`:

https://github.com/fluture-js/Fluture/blob/2f12660b744b28b3ed486f3dfef6bdf233dbd814/index.d.ts#L137-L143

Also relevant, the type of `pipe`:

https://github.com/fluture-js/Fluture/blob/2f12660b744b28b3ed486f3dfef6bdf233dbd814/index.d.ts#L36-L37
